### PR TITLE
CORE-3228: Add raw_probability to session proto

### DIFF
--- a/go/obb/session.pb.go
+++ b/go/obb/session.pb.go
@@ -606,9 +606,12 @@ type SessionMarketOutcome struct {
 	// Example: "10" for classic market or "od:player:123" for dynamic markets.
 	OutcomeId string `protobuf:"bytes,1,opt,name=outcome_id,json=outcomeId,proto3" json:"outcome_id,omitempty"`
 	// Odds multiplied by 10000 and rounded to uint value.
-	Odds          uint64 `protobuf:"varint,2,opt,name=odds,proto3" json:"odds,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	Odds uint64 `protobuf:"varint,2,opt,name=odds,proto3" json:"odds,omitempty"`
+	// Raw probability for this outcome (value between 0.0 and 1.0).
+	// This is the probability of this selection before margin is applied.
+	RawProbability float64 `protobuf:"fixed64,3,opt,name=raw_probability,json=rawProbability,proto3" json:"raw_probability,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
 }
 
 func (x *SessionMarketOutcome) Reset() {
@@ -651,6 +654,13 @@ func (x *SessionMarketOutcome) GetOutcomeId() string {
 func (x *SessionMarketOutcome) GetOdds() uint64 {
 	if x != nil {
 		return x.Odds
+	}
+	return 0
+}
+
+func (x *SessionMarketOutcome) GetRawProbability() float64 {
+	if x != nil {
+		return x.RawProbability
 	}
 	return 0
 }
@@ -821,8 +831,11 @@ type SessionCreateResponse_SessionCreated struct {
 	Odds uint64 `protobuf:"varint,2,opt,name=odds,proto3" json:"odds,omitempty"`
 	// Available markets for the new session with the current session selections.
 	AvailableMarkets []*SessionMarket `protobuf:"bytes,3,rep,name=available_markets,json=availableMarkets,proto3" json:"available_markets,omitempty"`
-	unknownFields    protoimpl.UnknownFields
-	sizeCache        protoimpl.SizeCache
+	// Raw probability of the selected combination (value between 0.0 and 1.0).
+	// This is the combined probability of all selections in the session before margin is applied.
+	RawProbability float64 `protobuf:"fixed64,4,opt,name=raw_probability,json=rawProbability,proto3" json:"raw_probability,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
 }
 
 func (x *SessionCreateResponse_SessionCreated) Reset() {
@@ -874,6 +887,13 @@ func (x *SessionCreateResponse_SessionCreated) GetAvailableMarkets() []*SessionM
 		return x.AvailableMarkets
 	}
 	return nil
+}
+
+func (x *SessionCreateResponse_SessionCreated) GetRawProbability() float64 {
+	if x != nil {
+		return x.RawProbability
+	}
+	return 0
 }
 
 type SessionCreateResponse_SessionRejected struct {
@@ -1088,18 +1108,19 @@ const file_obb_session_proto_rawDesc = "" +
 	"\fCODE_EXPIRED\x10\x03\x12\x12\n" +
 	"\x0eCODE_NOT_FOUND\x10\x04\";\n" +
 	"\x14SessionCreateRequest\x12#\n" +
-	"\rselection_ids\x18\x02 \x03(\tR\fselectionIds\"\x82\a\n" +
+	"\rselection_ids\x18\x02 \x03(\tR\fselectionIds\"\xab\a\n" +
 	"\x15SessionCreateResponse\x12\x1d\n" +
 	"\n" +
 	"session_id\x18\x01 \x01(\tR\tsessionId\x12E\n" +
 	"\acreated\x18\x02 \x01(\v2).obb.SessionCreateResponse.SessionCreatedH\x00R\acreated\x12H\n" +
-	"\brejected\x18\x03 \x01(\v2*.obb.SessionCreateResponse.SessionRejectedH\x00R\brejected\x1a\x9c\x01\n" +
+	"\brejected\x18\x03 \x01(\v2*.obb.SessionCreateResponse.SessionRejectedH\x00R\brejected\x1a\xc5\x01\n" +
 	"\x0eSessionCreated\x125\n" +
 	"\n" +
 	"selections\x18\x01 \x03(\v2\x15.obb.SessionSelectionR\n" +
 	"selections\x12\x12\n" +
 	"\x04odds\x18\x02 \x01(\x04R\x04odds\x12?\n" +
-	"\x11available_markets\x18\x03 \x03(\v2\x12.obb.SessionMarketR\x10availableMarkets\x1a\x8f\x04\n" +
+	"\x11available_markets\x18\x03 \x03(\v2\x12.obb.SessionMarketR\x10availableMarkets\x12'\n" +
+	"\x0fraw_probability\x18\x04 \x01(\x01R\x0erawProbability\x1a\x8f\x04\n" +
 	"\x0fSessionRejected\x120\n" +
 	"\x06reason\x18\x01 \x01(\v2\x18.obb.SessionRejectReasonR\x06reason\x12s\n" +
 	"\x13selections_rejected\x18\x02 \x03(\v2B.obb.SessionCreateResponse.SessionRejected.SelectionsRejectedEntryR\x12selectionsRejected\x1a\xc8\x01\n" +
@@ -1120,11 +1141,12 @@ const file_obb_session_proto_rawDesc = "" +
 	"\n" +
 	"specifiers\x18\x02 \x01(\tR\n" +
 	"specifiers\x125\n" +
-	"\boutcomes\x18\x03 \x03(\v2\x19.obb.SessionMarketOutcomeR\boutcomes\"I\n" +
+	"\boutcomes\x18\x03 \x03(\v2\x19.obb.SessionMarketOutcomeR\boutcomes\"r\n" +
 	"\x14SessionMarketOutcome\x12\x1d\n" +
 	"\n" +
 	"outcome_id\x18\x01 \x01(\tR\toutcomeId\x12\x12\n" +
-	"\x04odds\x18\x02 \x01(\x04R\x04odds\"~\n" +
+	"\x04odds\x18\x02 \x01(\x04R\x04odds\x12'\n" +
+	"\x0fraw_probability\x18\x03 \x01(\x01R\x0erawProbability\"~\n" +
 	"\x12SessionInfoRequest\x12\x1d\n" +
 	"\n" +
 	"session_id\x18\x01 \x01(\tR\tsessionId\x125\n" +

--- a/java/src/main/java/com/oddin/obb/Session.java
+++ b/java/src/main/java/com/oddin/obb/Session.java
@@ -2899,6 +2899,17 @@ public final class Session {
        */
       com.oddin.obb.Session.SessionMarketOrBuilder getAvailableMarketsOrBuilder(
           int index);
+
+      /**
+       * <pre>
+       * Raw probability of the selected combination (value between 0.0 and 1.0).
+       * This is the combined probability of all selections in the session before margin is applied.
+       * </pre>
+       *
+       * <code>double raw_probability = 4 [json_name = "rawProbability"];</code>
+       * @return The rawProbability.
+       */
+      double getRawProbability();
     }
     /**
      * Protobuf type {@code obb.SessionCreateResponse.SessionCreated}
@@ -3078,6 +3089,22 @@ public final class Session {
         return availableMarkets_.get(index);
       }
 
+      public static final int RAW_PROBABILITY_FIELD_NUMBER = 4;
+      private double rawProbability_;
+      /**
+       * <pre>
+       * Raw probability of the selected combination (value between 0.0 and 1.0).
+       * This is the combined probability of all selections in the session before margin is applied.
+       * </pre>
+       *
+       * <code>double raw_probability = 4 [json_name = "rawProbability"];</code>
+       * @return The rawProbability.
+       */
+      @java.lang.Override
+      public double getRawProbability() {
+        return rawProbability_;
+      }
+
       private byte memoizedIsInitialized = -1;
       @java.lang.Override
       public final boolean isInitialized() {
@@ -3101,6 +3128,9 @@ public final class Session {
         for (int i = 0; i < availableMarkets_.size(); i++) {
           output.writeMessage(3, availableMarkets_.get(i));
         }
+        if (java.lang.Double.doubleToRawLongBits(rawProbability_) != 0) {
+          output.writeDouble(4, rawProbability_);
+        }
         getUnknownFields().writeTo(output);
       }
 
@@ -3121,6 +3151,10 @@ public final class Session {
         for (int i = 0; i < availableMarkets_.size(); i++) {
           size += com.google.protobuf.CodedOutputStream
             .computeMessageSize(3, availableMarkets_.get(i));
+        }
+        if (java.lang.Double.doubleToRawLongBits(rawProbability_) != 0) {
+          size += com.google.protobuf.CodedOutputStream
+            .computeDoubleSize(4, rawProbability_);
         }
         size += getUnknownFields().getSerializedSize();
         memoizedSize = size;
@@ -3143,6 +3177,9 @@ public final class Session {
             != other.getOdds()) return false;
         if (!getAvailableMarketsList()
             .equals(other.getAvailableMarketsList())) return false;
+        if (java.lang.Double.doubleToLongBits(getRawProbability())
+            != java.lang.Double.doubleToLongBits(
+                other.getRawProbability())) return false;
         if (!getUnknownFields().equals(other.getUnknownFields())) return false;
         return true;
       }
@@ -3165,6 +3202,9 @@ public final class Session {
           hash = (37 * hash) + AVAILABLE_MARKETS_FIELD_NUMBER;
           hash = (53 * hash) + getAvailableMarketsList().hashCode();
         }
+        hash = (37 * hash) + RAW_PROBABILITY_FIELD_NUMBER;
+        hash = (53 * hash) + com.google.protobuf.Internal.hashLong(
+            java.lang.Double.doubleToLongBits(getRawProbability()));
         hash = (29 * hash) + getUnknownFields().hashCode();
         memoizedHashCode = hash;
         return hash;
@@ -3309,6 +3349,8 @@ public final class Session {
             availableMarketsBuilder_.clear();
           }
           bitField0_ = (bitField0_ & ~0x00000002);
+          rawProbability_ = 0D;
+
           return this;
         }
 
@@ -3355,6 +3397,7 @@ public final class Session {
           } else {
             result.availableMarkets_ = availableMarketsBuilder_.build();
           }
+          result.rawProbability_ = rawProbability_;
           onBuilt();
           return result;
         }
@@ -3458,6 +3501,9 @@ public final class Session {
               }
             }
           }
+          if (other.getRawProbability() != 0D) {
+            setRawProbability(other.getRawProbability());
+          }
           this.mergeUnknownFields(other.getUnknownFields());
           onChanged();
           return this;
@@ -3515,6 +3561,11 @@ public final class Session {
                   }
                   break;
                 } // case 26
+                case 33: {
+                  rawProbability_ = input.readDouble();
+
+                  break;
+                } // case 33
                 default: {
                   if (!super.parseUnknownField(input, extensionRegistry, tag)) {
                     done = true; // was an endgroup tag
@@ -4200,6 +4251,52 @@ public final class Session {
             availableMarkets_ = null;
           }
           return availableMarketsBuilder_;
+        }
+
+        private double rawProbability_ ;
+        /**
+         * <pre>
+         * Raw probability of the selected combination (value between 0.0 and 1.0).
+         * This is the combined probability of all selections in the session before margin is applied.
+         * </pre>
+         *
+         * <code>double raw_probability = 4 [json_name = "rawProbability"];</code>
+         * @return The rawProbability.
+         */
+        @java.lang.Override
+        public double getRawProbability() {
+          return rawProbability_;
+        }
+        /**
+         * <pre>
+         * Raw probability of the selected combination (value between 0.0 and 1.0).
+         * This is the combined probability of all selections in the session before margin is applied.
+         * </pre>
+         *
+         * <code>double raw_probability = 4 [json_name = "rawProbability"];</code>
+         * @param value The rawProbability to set.
+         * @return This builder for chaining.
+         */
+        public Builder setRawProbability(double value) {
+          
+          rawProbability_ = value;
+          onChanged();
+          return this;
+        }
+        /**
+         * <pre>
+         * Raw probability of the selected combination (value between 0.0 and 1.0).
+         * This is the combined probability of all selections in the session before margin is applied.
+         * </pre>
+         *
+         * <code>double raw_probability = 4 [json_name = "rawProbability"];</code>
+         * @return This builder for chaining.
+         */
+        public Builder clearRawProbability() {
+          
+          rawProbability_ = 0D;
+          onChanged();
+          return this;
         }
         @java.lang.Override
         public final Builder setUnknownFields(
@@ -9007,6 +9104,17 @@ com.oddin.obb.Session.SessionCreateResponse.SessionRejected.SelectionRejectedRea
      * @return The odds.
      */
     long getOdds();
+
+    /**
+     * <pre>
+     * Raw probability for this outcome (value between 0.0 and 1.0).
+     * This is the probability of this selection before margin is applied.
+     * </pre>
+     *
+     * <code>double raw_probability = 3 [json_name = "rawProbability"];</code>
+     * @return The rawProbability.
+     */
+    double getRawProbability();
   }
   /**
    * Protobuf type {@code obb.SessionMarketOutcome}
@@ -9112,6 +9220,22 @@ com.oddin.obb.Session.SessionCreateResponse.SessionRejected.SelectionRejectedRea
       return odds_;
     }
 
+    public static final int RAW_PROBABILITY_FIELD_NUMBER = 3;
+    private double rawProbability_;
+    /**
+     * <pre>
+     * Raw probability for this outcome (value between 0.0 and 1.0).
+     * This is the probability of this selection before margin is applied.
+     * </pre>
+     *
+     * <code>double raw_probability = 3 [json_name = "rawProbability"];</code>
+     * @return The rawProbability.
+     */
+    @java.lang.Override
+    public double getRawProbability() {
+      return rawProbability_;
+    }
+
     private byte memoizedIsInitialized = -1;
     @java.lang.Override
     public final boolean isInitialized() {
@@ -9132,6 +9256,9 @@ com.oddin.obb.Session.SessionCreateResponse.SessionRejected.SelectionRejectedRea
       if (odds_ != 0L) {
         output.writeUInt64(2, odds_);
       }
+      if (java.lang.Double.doubleToRawLongBits(rawProbability_) != 0) {
+        output.writeDouble(3, rawProbability_);
+      }
       getUnknownFields().writeTo(output);
     }
 
@@ -9147,6 +9274,10 @@ com.oddin.obb.Session.SessionCreateResponse.SessionRejected.SelectionRejectedRea
       if (odds_ != 0L) {
         size += com.google.protobuf.CodedOutputStream
           .computeUInt64Size(2, odds_);
+      }
+      if (java.lang.Double.doubleToRawLongBits(rawProbability_) != 0) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeDoubleSize(3, rawProbability_);
       }
       size += getUnknownFields().getSerializedSize();
       memoizedSize = size;
@@ -9167,6 +9298,9 @@ com.oddin.obb.Session.SessionCreateResponse.SessionRejected.SelectionRejectedRea
           .equals(other.getOutcomeId())) return false;
       if (getOdds()
           != other.getOdds()) return false;
+      if (java.lang.Double.doubleToLongBits(getRawProbability())
+          != java.lang.Double.doubleToLongBits(
+              other.getRawProbability())) return false;
       if (!getUnknownFields().equals(other.getUnknownFields())) return false;
       return true;
     }
@@ -9183,6 +9317,9 @@ com.oddin.obb.Session.SessionCreateResponse.SessionRejected.SelectionRejectedRea
       hash = (37 * hash) + ODDS_FIELD_NUMBER;
       hash = (53 * hash) + com.google.protobuf.Internal.hashLong(
           getOdds());
+      hash = (37 * hash) + RAW_PROBABILITY_FIELD_NUMBER;
+      hash = (53 * hash) + com.google.protobuf.Internal.hashLong(
+          java.lang.Double.doubleToLongBits(getRawProbability()));
       hash = (29 * hash) + getUnknownFields().hashCode();
       memoizedHashCode = hash;
       return hash;
@@ -9315,6 +9452,8 @@ com.oddin.obb.Session.SessionCreateResponse.SessionRejected.SelectionRejectedRea
 
         odds_ = 0L;
 
+        rawProbability_ = 0D;
+
         return this;
       }
 
@@ -9343,6 +9482,7 @@ com.oddin.obb.Session.SessionCreateResponse.SessionRejected.SelectionRejectedRea
         com.oddin.obb.Session.SessionMarketOutcome result = new com.oddin.obb.Session.SessionMarketOutcome(this);
         result.outcomeId_ = outcomeId_;
         result.odds_ = odds_;
+        result.rawProbability_ = rawProbability_;
         onBuilt();
         return result;
       }
@@ -9398,6 +9538,9 @@ com.oddin.obb.Session.SessionCreateResponse.SessionRejected.SelectionRejectedRea
         if (other.getOdds() != 0L) {
           setOdds(other.getOdds());
         }
+        if (other.getRawProbability() != 0D) {
+          setRawProbability(other.getRawProbability());
+        }
         this.mergeUnknownFields(other.getUnknownFields());
         onChanged();
         return this;
@@ -9434,6 +9577,11 @@ com.oddin.obb.Session.SessionCreateResponse.SessionRejected.SelectionRejectedRea
 
                 break;
               } // case 16
+              case 25: {
+                rawProbability_ = input.readDouble();
+
+                break;
+              } // case 25
               default: {
                 if (!super.parseUnknownField(input, extensionRegistry, tag)) {
                   done = true; // was an endgroup tag
@@ -9590,6 +9738,52 @@ com.oddin.obb.Session.SessionCreateResponse.SessionRejected.SelectionRejectedRea
       public Builder clearOdds() {
         
         odds_ = 0L;
+        onChanged();
+        return this;
+      }
+
+      private double rawProbability_ ;
+      /**
+       * <pre>
+       * Raw probability for this outcome (value between 0.0 and 1.0).
+       * This is the probability of this selection before margin is applied.
+       * </pre>
+       *
+       * <code>double raw_probability = 3 [json_name = "rawProbability"];</code>
+       * @return The rawProbability.
+       */
+      @java.lang.Override
+      public double getRawProbability() {
+        return rawProbability_;
+      }
+      /**
+       * <pre>
+       * Raw probability for this outcome (value between 0.0 and 1.0).
+       * This is the probability of this selection before margin is applied.
+       * </pre>
+       *
+       * <code>double raw_probability = 3 [json_name = "rawProbability"];</code>
+       * @param value The rawProbability to set.
+       * @return This builder for chaining.
+       */
+      public Builder setRawProbability(double value) {
+        
+        rawProbability_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * Raw probability for this outcome (value between 0.0 and 1.0).
+       * This is the probability of this selection before margin is applied.
+       * </pre>
+       *
+       * <code>double raw_probability = 3 [json_name = "rawProbability"];</code>
+       * @return This builder for chaining.
+       */
+      public Builder clearRawProbability() {
+        
+        rawProbability_ = 0D;
         onChanged();
         return this;
       }
@@ -13207,51 +13401,53 @@ com.oddin.obb.Session.SessionCreateResponse.SessionRejected.SelectionRejectedRea
       "\n\rCODE_INTERNAL\020\001\022\031\n\025CODE_INVALID_ARGUME" +
       "NT\020\002\022\020\n\014CODE_EXPIRED\020\003\022\022\n\016CODE_NOT_FOUND" +
       "\020\004\";\n\024SessionCreateRequest\022#\n\rselection_" +
-      "ids\030\002 \003(\tR\014selectionIds\"\202\007\n\025SessionCreat" +
+      "ids\030\002 \003(\tR\014selectionIds\"\253\007\n\025SessionCreat" +
       "eResponse\022\035\n\nsession_id\030\001 \001(\tR\tsessionId" +
       "\022E\n\007created\030\002 \001(\0132).obb.SessionCreateRes" +
       "ponse.SessionCreatedH\000R\007created\022H\n\010rejec" +
       "ted\030\003 \001(\0132*.obb.SessionCreateResponse.Se" +
-      "ssionRejectedH\000R\010rejected\032\234\001\n\016SessionCre" +
+      "ssionRejectedH\000R\010rejected\032\305\001\n\016SessionCre" +
       "ated\0225\n\nselections\030\001 \003(\0132\025.obb.SessionSe" +
       "lectionR\nselections\022\022\n\004odds\030\002 \001(\004R\004odds\022" +
       "?\n\021available_markets\030\003 \003(\0132\022.obb.Session" +
-      "MarketR\020availableMarkets\032\217\004\n\017SessionReje" +
-      "cted\0220\n\006reason\030\001 \001(\0132\030.obb.SessionReject" +
-      "ReasonR\006reason\022s\n\023selections_rejected\030\002 " +
-      "\003(\0132B.obb.SessionCreateResponse.SessionR" +
-      "ejected.SelectionsRejectedEntryR\022selecti" +
-      "onsRejected\032\310\001\n\027SelectionRejectedReason\022" +
-      "[\n\004code\030\001 \001(\0162G.obb.SessionCreateRespons" +
-      "e.SessionRejected.SelectionRejectedReaso" +
-      "n.CodeR\004code\022\030\n\007message\030\002 \001(\tR\007message\"6" +
-      "\n\004Code\022\024\n\020CODE_UNSPECIFIED\020\000\022\030\n\024CODE_INA" +
-      "CTIVE_MARKET\020\001\032\211\001\n\027SelectionsRejectedEnt" +
-      "ry\022\020\n\003key\030\001 \001(\tR\003key\022X\n\005value\030\002 \001(\0132B.ob" +
-      "b.SessionCreateResponse.SessionRejected." +
-      "SelectionRejectedReasonR\005value:\0028\001B\010\n\006st" +
-      "atus\"5\n\020SessionSelection\022!\n\014selection_id" +
-      "\030\001 \001(\tR\013selectionId\"\203\001\n\rSessionMarket\022\033\n" +
-      "\tmarket_id\030\001 \001(\rR\010marketId\022\036\n\nspecifiers" +
-      "\030\002 \001(\tR\nspecifiers\0225\n\010outcomes\030\003 \003(\0132\031.o" +
-      "bb.SessionMarketOutcomeR\010outcomes\"I\n\024Ses" +
-      "sionMarketOutcome\022\035\n\noutcome_id\030\001 \001(\tR\to" +
-      "utcomeId\022\022\n\004odds\030\002 \001(\004R\004odds\"~\n\022SessionI" +
-      "nfoRequest\022\035\n\nsession_id\030\001 \001(\tR\tsessionI" +
-      "d\0225\n\nselections\030\002 \003(\0132\025.obb.SessionSelec" +
-      "tionR\nselections\022\022\n\004odds\030\003 \001(\004R\004odds\"\227\002\n" +
-      "\023SessionInfoResponse\022\035\n\nsession_id\030\001 \001(\t" +
-      "R\tsessionId\022=\n\005valid\030\002 \001(\0132%.obb.Session" +
-      "InfoResponse.ValidSessionH\000R\005valid\022C\n\007in" +
-      "valid\030\003 \001(\0132\'.obb.SessionInfoResponse.In" +
-      "validSessionH\000R\007invalid\032\016\n\014ValidSession\032" +
-      "C\n\016InvalidSession\0221\n\006reason\030\001 \001(\0132\031.obb." +
-      "InvalidSessionReasonR\006reasonB\010\n\006status*e" +
-      "\n\rSessionStatus\022\036\n\032SESSION_STATUS_UNSPEC" +
-      "IFIED\020\000\022\030\n\024SESSION_STATUS_VALID\020\001\022\032\n\026SES" +
-      "SION_STATUS_INVALID\020\002B5\n\rcom.oddin.obbZ$" +
-      "github.com/oddin-gg/obbschema/go/obbb\006pr" +
-      "oto3"
+      "MarketR\020availableMarkets\022\'\n\017raw_probabil" +
+      "ity\030\004 \001(\001R\016rawProbability\032\217\004\n\017SessionRej" +
+      "ected\0220\n\006reason\030\001 \001(\0132\030.obb.SessionRejec" +
+      "tReasonR\006reason\022s\n\023selections_rejected\030\002" +
+      " \003(\0132B.obb.SessionCreateResponse.Session" +
+      "Rejected.SelectionsRejectedEntryR\022select" +
+      "ionsRejected\032\310\001\n\027SelectionRejectedReason" +
+      "\022[\n\004code\030\001 \001(\0162G.obb.SessionCreateRespon" +
+      "se.SessionRejected.SelectionRejectedReas" +
+      "on.CodeR\004code\022\030\n\007message\030\002 \001(\tR\007message\"" +
+      "6\n\004Code\022\024\n\020CODE_UNSPECIFIED\020\000\022\030\n\024CODE_IN" +
+      "ACTIVE_MARKET\020\001\032\211\001\n\027SelectionsRejectedEn" +
+      "try\022\020\n\003key\030\001 \001(\tR\003key\022X\n\005value\030\002 \001(\0132B.o" +
+      "bb.SessionCreateResponse.SessionRejected" +
+      ".SelectionRejectedReasonR\005value:\0028\001B\010\n\006s" +
+      "tatus\"5\n\020SessionSelection\022!\n\014selection_i" +
+      "d\030\001 \001(\tR\013selectionId\"\203\001\n\rSessionMarket\022\033" +
+      "\n\tmarket_id\030\001 \001(\rR\010marketId\022\036\n\nspecifier" +
+      "s\030\002 \001(\tR\nspecifiers\0225\n\010outcomes\030\003 \003(\0132\031." +
+      "obb.SessionMarketOutcomeR\010outcomes\"r\n\024Se" +
+      "ssionMarketOutcome\022\035\n\noutcome_id\030\001 \001(\tR\t" +
+      "outcomeId\022\022\n\004odds\030\002 \001(\004R\004odds\022\'\n\017raw_pro" +
+      "bability\030\003 \001(\001R\016rawProbability\"~\n\022Sessio" +
+      "nInfoRequest\022\035\n\nsession_id\030\001 \001(\tR\tsessio" +
+      "nId\0225\n\nselections\030\002 \003(\0132\025.obb.SessionSel" +
+      "ectionR\nselections\022\022\n\004odds\030\003 \001(\004R\004odds\"\227" +
+      "\002\n\023SessionInfoResponse\022\035\n\nsession_id\030\001 \001" +
+      "(\tR\tsessionId\022=\n\005valid\030\002 \001(\0132%.obb.Sessi" +
+      "onInfoResponse.ValidSessionH\000R\005valid\022C\n\007" +
+      "invalid\030\003 \001(\0132\'.obb.SessionInfoResponse." +
+      "InvalidSessionH\000R\007invalid\032\016\n\014ValidSessio" +
+      "n\032C\n\016InvalidSession\0221\n\006reason\030\001 \001(\0132\031.ob" +
+      "b.InvalidSessionReasonR\006reasonB\010\n\006status" +
+      "*e\n\rSessionStatus\022\036\n\032SESSION_STATUS_UNSP" +
+      "ECIFIED\020\000\022\030\n\024SESSION_STATUS_VALID\020\001\022\032\n\026S" +
+      "ESSION_STATUS_INVALID\020\002B5\n\rcom.oddin.obb" +
+      "Z$github.com/oddin-gg/obbschema/go/obbb\006" +
+      "proto3"
     };
     descriptor = com.google.protobuf.Descriptors.FileDescriptor
       .internalBuildGeneratedFileFrom(descriptorData,
@@ -13286,7 +13482,7 @@ com.oddin.obb.Session.SessionCreateResponse.SessionRejected.SelectionRejectedRea
     internal_static_obb_SessionCreateResponse_SessionCreated_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_obb_SessionCreateResponse_SessionCreated_descriptor,
-        new java.lang.String[] { "Selections", "Odds", "AvailableMarkets", });
+        new java.lang.String[] { "Selections", "Odds", "AvailableMarkets", "RawProbability", });
     internal_static_obb_SessionCreateResponse_SessionRejected_descriptor =
       internal_static_obb_SessionCreateResponse_descriptor.getNestedTypes().get(1);
     internal_static_obb_SessionCreateResponse_SessionRejected_fieldAccessorTable = new
@@ -13322,7 +13518,7 @@ com.oddin.obb.Session.SessionCreateResponse.SessionRejected.SelectionRejectedRea
     internal_static_obb_SessionMarketOutcome_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_obb_SessionMarketOutcome_descriptor,
-        new java.lang.String[] { "OutcomeId", "Odds", });
+        new java.lang.String[] { "OutcomeId", "Odds", "RawProbability", });
     internal_static_obb_SessionInfoRequest_descriptor =
       getDescriptor().getMessageTypes().get(7);
     internal_static_obb_SessionInfoRequest_fieldAccessorTable = new

--- a/js/obb/session_pb.d.ts
+++ b/js/obb/session_pb.d.ts
@@ -139,6 +139,9 @@ export namespace SessionCreateResponse {
     setAvailableMarketsList(value: Array<SessionMarket>): void;
     addAvailableMarkets(value?: SessionMarket, index?: number): SessionMarket;
 
+    getRawProbability(): number;
+    setRawProbability(value: number): void;
+
     serializeBinary(): Uint8Array;
     toObject(includeInstance?: boolean): SessionCreated.AsObject;
     static toObject(includeInstance: boolean, msg: SessionCreated): SessionCreated.AsObject;
@@ -154,6 +157,7 @@ export namespace SessionCreateResponse {
       selectionsList: Array<SessionSelection.AsObject>,
       odds: number,
       availableMarketsList: Array<SessionMarket.AsObject>,
+      rawProbability: number,
     }
   }
 
@@ -277,6 +281,9 @@ export class SessionMarketOutcome extends jspb.Message {
   getOdds(): number;
   setOdds(value: number): void;
 
+  getRawProbability(): number;
+  setRawProbability(value: number): void;
+
   serializeBinary(): Uint8Array;
   toObject(includeInstance?: boolean): SessionMarketOutcome.AsObject;
   static toObject(includeInstance: boolean, msg: SessionMarketOutcome): SessionMarketOutcome.AsObject;
@@ -291,6 +298,7 @@ export namespace SessionMarketOutcome {
   export type AsObject = {
     outcomeId: string,
     odds: number,
+    rawProbability: number,
   }
 }
 

--- a/js/obb/session_pb.js
+++ b/js/obb/session_pb.js
@@ -1042,7 +1042,8 @@ proto.obb.SessionCreateResponse.SessionCreated.toObject = function(includeInstan
     proto.obb.SessionSelection.toObject, includeInstance),
     odds: jspb.Message.getFieldWithDefault(msg, 2, 0),
     availableMarketsList: jspb.Message.toObjectList(msg.getAvailableMarketsList(),
-    proto.obb.SessionMarket.toObject, includeInstance)
+    proto.obb.SessionMarket.toObject, includeInstance),
+    rawProbability: jspb.Message.getFloatingPointFieldWithDefault(msg, 4, 0.0)
   };
 
   if (includeInstance) {
@@ -1092,6 +1093,10 @@ proto.obb.SessionCreateResponse.SessionCreated.deserializeBinaryFromReader = fun
       var value = new proto.obb.SessionMarket;
       reader.readMessage(value,proto.obb.SessionMarket.deserializeBinaryFromReader);
       msg.addAvailableMarkets(value);
+      break;
+    case 4:
+      var value = /** @type {number} */ (reader.readDouble());
+      msg.setRawProbability(value);
       break;
     default:
       reader.skipField();
@@ -1143,6 +1148,13 @@ proto.obb.SessionCreateResponse.SessionCreated.serializeBinaryToWriter = functio
       3,
       f,
       proto.obb.SessionMarket.serializeBinaryToWriter
+    );
+  }
+  f = message.getRawProbability();
+  if (f !== 0.0) {
+    writer.writeDouble(
+      4,
+      f
     );
   }
 };
@@ -1239,6 +1251,24 @@ proto.obb.SessionCreateResponse.SessionCreated.prototype.addAvailableMarkets = f
  */
 proto.obb.SessionCreateResponse.SessionCreated.prototype.clearAvailableMarketsList = function() {
   return this.setAvailableMarketsList([]);
+};
+
+
+/**
+ * optional double raw_probability = 4;
+ * @return {number}
+ */
+proto.obb.SessionCreateResponse.SessionCreated.prototype.getRawProbability = function() {
+  return /** @type {number} */ (jspb.Message.getFloatingPointFieldWithDefault(this, 4, 0.0));
+};
+
+
+/**
+ * @param {number} value
+ * @return {!proto.obb.SessionCreateResponse.SessionCreated} returns this
+ */
+proto.obb.SessionCreateResponse.SessionCreated.prototype.setRawProbability = function(value) {
+  return jspb.Message.setProto3FloatField(this, 4, value);
 };
 
 
@@ -2069,7 +2099,8 @@ proto.obb.SessionMarketOutcome.prototype.toObject = function(opt_includeInstance
 proto.obb.SessionMarketOutcome.toObject = function(includeInstance, msg) {
   var f, obj = {
     outcomeId: jspb.Message.getFieldWithDefault(msg, 1, ""),
-    odds: jspb.Message.getFieldWithDefault(msg, 2, 0)
+    odds: jspb.Message.getFieldWithDefault(msg, 2, 0),
+    rawProbability: jspb.Message.getFloatingPointFieldWithDefault(msg, 3, 0.0)
   };
 
   if (includeInstance) {
@@ -2114,6 +2145,10 @@ proto.obb.SessionMarketOutcome.deserializeBinaryFromReader = function(msg, reade
       var value = /** @type {number} */ (reader.readUint64());
       msg.setOdds(value);
       break;
+    case 3:
+      var value = /** @type {number} */ (reader.readDouble());
+      msg.setRawProbability(value);
+      break;
     default:
       reader.skipField();
       break;
@@ -2157,6 +2192,13 @@ proto.obb.SessionMarketOutcome.serializeBinaryToWriter = function(message, write
       f
     );
   }
+  f = message.getRawProbability();
+  if (f !== 0.0) {
+    writer.writeDouble(
+      3,
+      f
+    );
+  }
 };
 
 
@@ -2193,6 +2235,24 @@ proto.obb.SessionMarketOutcome.prototype.getOdds = function() {
  */
 proto.obb.SessionMarketOutcome.prototype.setOdds = function(value) {
   return jspb.Message.setProto3IntField(this, 2, value);
+};
+
+
+/**
+ * optional double raw_probability = 3;
+ * @return {number}
+ */
+proto.obb.SessionMarketOutcome.prototype.getRawProbability = function() {
+  return /** @type {number} */ (jspb.Message.getFloatingPointFieldWithDefault(this, 3, 0.0));
+};
+
+
+/**
+ * @param {number} value
+ * @return {!proto.obb.SessionMarketOutcome} returns this
+ */
+proto.obb.SessionMarketOutcome.prototype.setRawProbability = function(value) {
+  return jspb.Message.setProto3FloatField(this, 3, value);
 };
 
 

--- a/proto/obb/session.proto
+++ b/proto/obb/session.proto
@@ -85,6 +85,10 @@ message SessionCreateResponse {
 
     // Available markets for the new session with the current session selections.
     repeated SessionMarket available_markets = 3;
+
+    // Raw probability of the selected combination (value between 0.0 and 1.0).
+    // This is the combined probability of all selections in the session before margin is applied.
+    double raw_probability = 4;
   }
 
   message SessionRejected {
@@ -146,6 +150,10 @@ message SessionMarketOutcome {
 
   // Odds multiplied by 10000 and rounded to uint value.
   uint64 odds = 2;
+
+  // Raw probability for this outcome (value between 0.0 and 1.0).
+  // This is the probability of this selection before margin is applied.
+  double raw_probability = 3;
 }
 
 message SessionInfoRequest {

--- a/python/obb/session_pb2.py
+++ b/python/obb/session_pb2.py
@@ -24,7 +24,7 @@ _sym_db = _symbol_database.Default()
 
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x11obb/session.proto\x12\x03obb\"\xee\x01\n\x13SessionRejectReason\x12\x31\n\x04\x63ode\x18\x01 \x01(\x0e\x32\x1d.obb.SessionRejectReason.CodeR\x04\x63ode\x12\x18\n\x07message\x18\x02 \x01(\tR\x07message\"\x89\x01\n\x04\x43ode\x12\x14\n\x10\x43ODE_UNSPECIFIED\x10\x00\x12\x11\n\rCODE_INTERNAL\x10\x01\x12\x19\n\x15\x43ODE_INVALID_ARGUMENT\x10\x02\x12#\n\x1f\x43ODE_INVALID_MARKET_COMBINATION\x10\x03\x12\x18\n\x14\x43ODE_INACTIVE_MARKET\x10\x04\"\xd6\x01\n\x14InvalidSessionReason\x12\x32\n\x04\x63ode\x18\x01 \x01(\x0e\x32\x1e.obb.InvalidSessionReason.CodeR\x04\x63ode\x12\x18\n\x07message\x18\x02 \x01(\tR\x07message\"p\n\x04\x43ode\x12\x14\n\x10\x43ODE_UNSPECIFIED\x10\x00\x12\x11\n\rCODE_INTERNAL\x10\x01\x12\x19\n\x15\x43ODE_INVALID_ARGUMENT\x10\x02\x12\x10\n\x0c\x43ODE_EXPIRED\x10\x03\x12\x12\n\x0e\x43ODE_NOT_FOUND\x10\x04\";\n\x14SessionCreateRequest\x12#\n\rselection_ids\x18\x02 \x03(\tR\x0cselectionIds\"\x82\x07\n\x15SessionCreateResponse\x12\x1d\n\nsession_id\x18\x01 \x01(\tR\tsessionId\x12\x45\n\x07\x63reated\x18\x02 \x01(\x0b\x32).obb.SessionCreateResponse.SessionCreatedH\x00R\x07\x63reated\x12H\n\x08rejected\x18\x03 \x01(\x0b\x32*.obb.SessionCreateResponse.SessionRejectedH\x00R\x08rejected\x1a\x9c\x01\n\x0eSessionCreated\x12\x35\n\nselections\x18\x01 \x03(\x0b\x32\x15.obb.SessionSelectionR\nselections\x12\x12\n\x04odds\x18\x02 \x01(\x04R\x04odds\x12?\n\x11\x61vailable_markets\x18\x03 \x03(\x0b\x32\x12.obb.SessionMarketR\x10\x61vailableMarkets\x1a\x8f\x04\n\x0fSessionRejected\x12\x30\n\x06reason\x18\x01 \x01(\x0b\x32\x18.obb.SessionRejectReasonR\x06reason\x12s\n\x13selections_rejected\x18\x02 \x03(\x0b\x32\x42.obb.SessionCreateResponse.SessionRejected.SelectionsRejectedEntryR\x12selectionsRejected\x1a\xc8\x01\n\x17SelectionRejectedReason\x12[\n\x04\x63ode\x18\x01 \x01(\x0e\x32G.obb.SessionCreateResponse.SessionRejected.SelectionRejectedReason.CodeR\x04\x63ode\x12\x18\n\x07message\x18\x02 \x01(\tR\x07message\"6\n\x04\x43ode\x12\x14\n\x10\x43ODE_UNSPECIFIED\x10\x00\x12\x18\n\x14\x43ODE_INACTIVE_MARKET\x10\x01\x1a\x89\x01\n\x17SelectionsRejectedEntry\x12\x10\n\x03key\x18\x01 \x01(\tR\x03key\x12X\n\x05value\x18\x02 \x01(\x0b\x32\x42.obb.SessionCreateResponse.SessionRejected.SelectionRejectedReasonR\x05value:\x02\x38\x01\x42\x08\n\x06status\"5\n\x10SessionSelection\x12!\n\x0cselection_id\x18\x01 \x01(\tR\x0bselectionId\"\x83\x01\n\rSessionMarket\x12\x1b\n\tmarket_id\x18\x01 \x01(\rR\x08marketId\x12\x1e\n\nspecifiers\x18\x02 \x01(\tR\nspecifiers\x12\x35\n\x08outcomes\x18\x03 \x03(\x0b\x32\x19.obb.SessionMarketOutcomeR\x08outcomes\"I\n\x14SessionMarketOutcome\x12\x1d\n\noutcome_id\x18\x01 \x01(\tR\toutcomeId\x12\x12\n\x04odds\x18\x02 \x01(\x04R\x04odds\"~\n\x12SessionInfoRequest\x12\x1d\n\nsession_id\x18\x01 \x01(\tR\tsessionId\x12\x35\n\nselections\x18\x02 \x03(\x0b\x32\x15.obb.SessionSelectionR\nselections\x12\x12\n\x04odds\x18\x03 \x01(\x04R\x04odds\"\x97\x02\n\x13SessionInfoResponse\x12\x1d\n\nsession_id\x18\x01 \x01(\tR\tsessionId\x12=\n\x05valid\x18\x02 \x01(\x0b\x32%.obb.SessionInfoResponse.ValidSessionH\x00R\x05valid\x12\x43\n\x07invalid\x18\x03 \x01(\x0b\x32\'.obb.SessionInfoResponse.InvalidSessionH\x00R\x07invalid\x1a\x0e\n\x0cValidSession\x1a\x43\n\x0eInvalidSession\x12\x31\n\x06reason\x18\x01 \x01(\x0b\x32\x19.obb.InvalidSessionReasonR\x06reasonB\x08\n\x06status*e\n\rSessionStatus\x12\x1e\n\x1aSESSION_STATUS_UNSPECIFIED\x10\x00\x12\x18\n\x14SESSION_STATUS_VALID\x10\x01\x12\x1a\n\x16SESSION_STATUS_INVALID\x10\x02\x42\x35\n\rcom.oddin.obbZ$github.com/oddin-gg/obbschema/go/obbb\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x11obb/session.proto\x12\x03obb\"\xee\x01\n\x13SessionRejectReason\x12\x31\n\x04\x63ode\x18\x01 \x01(\x0e\x32\x1d.obb.SessionRejectReason.CodeR\x04\x63ode\x12\x18\n\x07message\x18\x02 \x01(\tR\x07message\"\x89\x01\n\x04\x43ode\x12\x14\n\x10\x43ODE_UNSPECIFIED\x10\x00\x12\x11\n\rCODE_INTERNAL\x10\x01\x12\x19\n\x15\x43ODE_INVALID_ARGUMENT\x10\x02\x12#\n\x1f\x43ODE_INVALID_MARKET_COMBINATION\x10\x03\x12\x18\n\x14\x43ODE_INACTIVE_MARKET\x10\x04\"\xd6\x01\n\x14InvalidSessionReason\x12\x32\n\x04\x63ode\x18\x01 \x01(\x0e\x32\x1e.obb.InvalidSessionReason.CodeR\x04\x63ode\x12\x18\n\x07message\x18\x02 \x01(\tR\x07message\"p\n\x04\x43ode\x12\x14\n\x10\x43ODE_UNSPECIFIED\x10\x00\x12\x11\n\rCODE_INTERNAL\x10\x01\x12\x19\n\x15\x43ODE_INVALID_ARGUMENT\x10\x02\x12\x10\n\x0c\x43ODE_EXPIRED\x10\x03\x12\x12\n\x0e\x43ODE_NOT_FOUND\x10\x04\";\n\x14SessionCreateRequest\x12#\n\rselection_ids\x18\x02 \x03(\tR\x0cselectionIds\"\xab\x07\n\x15SessionCreateResponse\x12\x1d\n\nsession_id\x18\x01 \x01(\tR\tsessionId\x12\x45\n\x07\x63reated\x18\x02 \x01(\x0b\x32).obb.SessionCreateResponse.SessionCreatedH\x00R\x07\x63reated\x12H\n\x08rejected\x18\x03 \x01(\x0b\x32*.obb.SessionCreateResponse.SessionRejectedH\x00R\x08rejected\x1a\xc5\x01\n\x0eSessionCreated\x12\x35\n\nselections\x18\x01 \x03(\x0b\x32\x15.obb.SessionSelectionR\nselections\x12\x12\n\x04odds\x18\x02 \x01(\x04R\x04odds\x12?\n\x11\x61vailable_markets\x18\x03 \x03(\x0b\x32\x12.obb.SessionMarketR\x10\x61vailableMarkets\x12\'\n\x0fraw_probability\x18\x04 \x01(\x01R\x0erawProbability\x1a\x8f\x04\n\x0fSessionRejected\x12\x30\n\x06reason\x18\x01 \x01(\x0b\x32\x18.obb.SessionRejectReasonR\x06reason\x12s\n\x13selections_rejected\x18\x02 \x03(\x0b\x32\x42.obb.SessionCreateResponse.SessionRejected.SelectionsRejectedEntryR\x12selectionsRejected\x1a\xc8\x01\n\x17SelectionRejectedReason\x12[\n\x04\x63ode\x18\x01 \x01(\x0e\x32G.obb.SessionCreateResponse.SessionRejected.SelectionRejectedReason.CodeR\x04\x63ode\x12\x18\n\x07message\x18\x02 \x01(\tR\x07message\"6\n\x04\x43ode\x12\x14\n\x10\x43ODE_UNSPECIFIED\x10\x00\x12\x18\n\x14\x43ODE_INACTIVE_MARKET\x10\x01\x1a\x89\x01\n\x17SelectionsRejectedEntry\x12\x10\n\x03key\x18\x01 \x01(\tR\x03key\x12X\n\x05value\x18\x02 \x01(\x0b\x32\x42.obb.SessionCreateResponse.SessionRejected.SelectionRejectedReasonR\x05value:\x02\x38\x01\x42\x08\n\x06status\"5\n\x10SessionSelection\x12!\n\x0cselection_id\x18\x01 \x01(\tR\x0bselectionId\"\x83\x01\n\rSessionMarket\x12\x1b\n\tmarket_id\x18\x01 \x01(\rR\x08marketId\x12\x1e\n\nspecifiers\x18\x02 \x01(\tR\nspecifiers\x12\x35\n\x08outcomes\x18\x03 \x03(\x0b\x32\x19.obb.SessionMarketOutcomeR\x08outcomes\"r\n\x14SessionMarketOutcome\x12\x1d\n\noutcome_id\x18\x01 \x01(\tR\toutcomeId\x12\x12\n\x04odds\x18\x02 \x01(\x04R\x04odds\x12\'\n\x0fraw_probability\x18\x03 \x01(\x01R\x0erawProbability\"~\n\x12SessionInfoRequest\x12\x1d\n\nsession_id\x18\x01 \x01(\tR\tsessionId\x12\x35\n\nselections\x18\x02 \x03(\x0b\x32\x15.obb.SessionSelectionR\nselections\x12\x12\n\x04odds\x18\x03 \x01(\x04R\x04odds\"\x97\x02\n\x13SessionInfoResponse\x12\x1d\n\nsession_id\x18\x01 \x01(\tR\tsessionId\x12=\n\x05valid\x18\x02 \x01(\x0b\x32%.obb.SessionInfoResponse.ValidSessionH\x00R\x05valid\x12\x43\n\x07invalid\x18\x03 \x01(\x0b\x32\'.obb.SessionInfoResponse.InvalidSessionH\x00R\x07invalid\x1a\x0e\n\x0cValidSession\x1a\x43\n\x0eInvalidSession\x12\x31\n\x06reason\x18\x01 \x01(\x0b\x32\x19.obb.InvalidSessionReasonR\x06reasonB\x08\n\x06status*e\n\rSessionStatus\x12\x1e\n\x1aSESSION_STATUS_UNSPECIFIED\x10\x00\x12\x18\n\x14SESSION_STATUS_VALID\x10\x01\x12\x1a\n\x16SESSION_STATUS_INVALID\x10\x02\x42\x35\n\rcom.oddin.obbZ$github.com/oddin-gg/obbschema/go/obbb\x06proto3')
 
 _globals = globals()
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
@@ -34,8 +34,8 @@ if not _descriptor._USE_C_DESCRIPTORS:
   _globals['DESCRIPTOR']._serialized_options = b'\n\rcom.oddin.obbZ$github.com/oddin-gg/obbschema/go/obb'
   _globals['_SESSIONCREATERESPONSE_SESSIONREJECTED_SELECTIONSREJECTEDENTRY']._loaded_options = None
   _globals['_SESSIONCREATERESPONSE_SESSIONREJECTED_SELECTIONSREJECTEDENTRY']._serialized_options = b'8\001'
-  _globals['_SESSIONSTATUS']._serialized_start=2120
-  _globals['_SESSIONSTATUS']._serialized_end=2221
+  _globals['_SESSIONSTATUS']._serialized_start=2202
+  _globals['_SESSIONSTATUS']._serialized_end=2303
   _globals['_SESSIONREJECTREASON']._serialized_start=27
   _globals['_SESSIONREJECTREASON']._serialized_end=265
   _globals['_SESSIONREJECTREASON_CODE']._serialized_start=128
@@ -47,29 +47,29 @@ if not _descriptor._USE_C_DESCRIPTORS:
   _globals['_SESSIONCREATEREQUEST']._serialized_start=484
   _globals['_SESSIONCREATEREQUEST']._serialized_end=543
   _globals['_SESSIONCREATERESPONSE']._serialized_start=546
-  _globals['_SESSIONCREATERESPONSE']._serialized_end=1444
+  _globals['_SESSIONCREATERESPONSE']._serialized_end=1485
   _globals['_SESSIONCREATERESPONSE_SESSIONCREATED']._serialized_start=748
-  _globals['_SESSIONCREATERESPONSE_SESSIONCREATED']._serialized_end=904
-  _globals['_SESSIONCREATERESPONSE_SESSIONREJECTED']._serialized_start=907
-  _globals['_SESSIONCREATERESPONSE_SESSIONREJECTED']._serialized_end=1434
-  _globals['_SESSIONCREATERESPONSE_SESSIONREJECTED_SELECTIONREJECTEDREASON']._serialized_start=1094
-  _globals['_SESSIONCREATERESPONSE_SESSIONREJECTED_SELECTIONREJECTEDREASON']._serialized_end=1294
-  _globals['_SESSIONCREATERESPONSE_SESSIONREJECTED_SELECTIONREJECTEDREASON_CODE']._serialized_start=1240
-  _globals['_SESSIONCREATERESPONSE_SESSIONREJECTED_SELECTIONREJECTEDREASON_CODE']._serialized_end=1294
-  _globals['_SESSIONCREATERESPONSE_SESSIONREJECTED_SELECTIONSREJECTEDENTRY']._serialized_start=1297
-  _globals['_SESSIONCREATERESPONSE_SESSIONREJECTED_SELECTIONSREJECTEDENTRY']._serialized_end=1434
-  _globals['_SESSIONSELECTION']._serialized_start=1446
-  _globals['_SESSIONSELECTION']._serialized_end=1499
-  _globals['_SESSIONMARKET']._serialized_start=1502
-  _globals['_SESSIONMARKET']._serialized_end=1633
-  _globals['_SESSIONMARKETOUTCOME']._serialized_start=1635
-  _globals['_SESSIONMARKETOUTCOME']._serialized_end=1708
-  _globals['_SESSIONINFOREQUEST']._serialized_start=1710
-  _globals['_SESSIONINFOREQUEST']._serialized_end=1836
-  _globals['_SESSIONINFORESPONSE']._serialized_start=1839
-  _globals['_SESSIONINFORESPONSE']._serialized_end=2118
-  _globals['_SESSIONINFORESPONSE_VALIDSESSION']._serialized_start=2025
-  _globals['_SESSIONINFORESPONSE_VALIDSESSION']._serialized_end=2039
-  _globals['_SESSIONINFORESPONSE_INVALIDSESSION']._serialized_start=2041
-  _globals['_SESSIONINFORESPONSE_INVALIDSESSION']._serialized_end=2108
+  _globals['_SESSIONCREATERESPONSE_SESSIONCREATED']._serialized_end=945
+  _globals['_SESSIONCREATERESPONSE_SESSIONREJECTED']._serialized_start=948
+  _globals['_SESSIONCREATERESPONSE_SESSIONREJECTED']._serialized_end=1475
+  _globals['_SESSIONCREATERESPONSE_SESSIONREJECTED_SELECTIONREJECTEDREASON']._serialized_start=1135
+  _globals['_SESSIONCREATERESPONSE_SESSIONREJECTED_SELECTIONREJECTEDREASON']._serialized_end=1335
+  _globals['_SESSIONCREATERESPONSE_SESSIONREJECTED_SELECTIONREJECTEDREASON_CODE']._serialized_start=1281
+  _globals['_SESSIONCREATERESPONSE_SESSIONREJECTED_SELECTIONREJECTEDREASON_CODE']._serialized_end=1335
+  _globals['_SESSIONCREATERESPONSE_SESSIONREJECTED_SELECTIONSREJECTEDENTRY']._serialized_start=1338
+  _globals['_SESSIONCREATERESPONSE_SESSIONREJECTED_SELECTIONSREJECTEDENTRY']._serialized_end=1475
+  _globals['_SESSIONSELECTION']._serialized_start=1487
+  _globals['_SESSIONSELECTION']._serialized_end=1540
+  _globals['_SESSIONMARKET']._serialized_start=1543
+  _globals['_SESSIONMARKET']._serialized_end=1674
+  _globals['_SESSIONMARKETOUTCOME']._serialized_start=1676
+  _globals['_SESSIONMARKETOUTCOME']._serialized_end=1790
+  _globals['_SESSIONINFOREQUEST']._serialized_start=1792
+  _globals['_SESSIONINFOREQUEST']._serialized_end=1918
+  _globals['_SESSIONINFORESPONSE']._serialized_start=1921
+  _globals['_SESSIONINFORESPONSE']._serialized_end=2200
+  _globals['_SESSIONINFORESPONSE_VALIDSESSION']._serialized_start=2107
+  _globals['_SESSIONINFORESPONSE_VALIDSESSION']._serialized_end=2121
+  _globals['_SESSIONINFORESPONSE_INVALIDSESSION']._serialized_start=2123
+  _globals['_SESSIONINFORESPONSE_INVALIDSESSION']._serialized_end=2190
 # @@protoc_insertion_point(module_scope)


### PR DESCRIPTION
## Summary
- Add `double raw_probability` field to `SessionCreated` message (field 4) — combined probability of all selections in the session
- Add `double raw_probability` field to `SessionMarketOutcome` message (field 3) — per-outcome probability before margin

## Context
Client Betclic (ID: 260) requested probabilities on OBB session selections to support cashout calculations ([OGC-1486](https://oddingg.atlassian.net/browse/OGC-1486)). Saibot already calculates these probabilities internally; this change exposes them in the session response proto so Fujin can surface them to clients.

## Notes
- Proto-only change — generated code (Go/Java/JS/Python) needs to be regenerated via `generate.sh`
- Fully backward compatible — new `double` fields default to `0.0` for existing clients
- Fujin implementation tracked in [CORE-3228](https://oddingg.atlassian.net/browse/CORE-3228)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[OGC-1486]: https://oddingg.atlassian.net/browse/OGC-1486?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CORE-3228]: https://oddingg.atlassian.net/browse/CORE-3228?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ