### PR TITLE
CORE-3868: Replace PopularCombination schema with session-ready combinations

### DIFF
--- a/go/obb/popular.pb.go
+++ b/go/obb/popular.pb.go
@@ -68,8 +68,9 @@ func (x *PopularCombinationRequest) GetEventId() string {
 
 type PopularCombinationResponse struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// List of popular markets for OBB combinations.
-	Markets       []*PopularCombinationMarket `protobuf:"bytes,1,rep,name=markets,proto3" json:"markets,omitempty"`
+	// Popular selection combinations for the event, ready to be used
+	// in SessionCreateRequest without further processing.
+	Combinations  []*PopularCombination `protobuf:"bytes,2,rep,name=combinations,proto3" json:"combinations,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -104,38 +105,44 @@ func (*PopularCombinationResponse) Descriptor() ([]byte, []int) {
 	return file_obb_popular_proto_rawDescGZIP(), []int{1}
 }
 
-func (x *PopularCombinationResponse) GetMarkets() []*PopularCombinationMarket {
+func (x *PopularCombinationResponse) GetCombinations() []*PopularCombination {
 	if x != nil {
-		return x.Markets
+		return x.Combinations
 	}
 	return nil
 }
 
-type PopularCombinationMarket struct {
+type PopularCombination struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// The ID using the same values as our odds feed in XML.
-	MarketId uint32 `protobuf:"varint,1,opt,name=market_id,json=marketId,proto3" json:"market_id,omitempty"`
-	// The specifier is using the same values as our odds feed in XML.
-	// Example: "variant=way:three|way=three|map=1"
-	Specifiers    string `protobuf:"bytes,2,opt,name=specifiers,proto3" json:"specifiers,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	// Selections forming the combination, in the same format as
+	// SessionCreateRequest.selection_ids:
+	// "<event_id>/<market_id>/<outcome_id>?<market_specifier>"
+	// Example: "od:match:1234/1/1?map=1&way=two"
+	SelectionIds []string `protobuf:"bytes,1,rep,name=selection_ids,json=selectionIds,proto3" json:"selection_ids,omitempty"`
+	// Total odds for the whole combination.
+	// Odds multiplied by 10000 and rounded to uint value.
+	Odds uint64 `protobuf:"varint,2,opt,name=odds,proto3" json:"odds,omitempty"`
+	// Raw probability of the combination (value between 0.0 and 1.0).
+	// This is the combined probability of all selections before margin is applied.
+	RawProbability float64 `protobuf:"fixed64,3,opt,name=raw_probability,json=rawProbability,proto3" json:"raw_probability,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
 }
 
-func (x *PopularCombinationMarket) Reset() {
-	*x = PopularCombinationMarket{}
+func (x *PopularCombination) Reset() {
+	*x = PopularCombination{}
 	mi := &file_obb_popular_proto_msgTypes[2]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
 
-func (x *PopularCombinationMarket) String() string {
+func (x *PopularCombination) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*PopularCombinationMarket) ProtoMessage() {}
+func (*PopularCombination) ProtoMessage() {}
 
-func (x *PopularCombinationMarket) ProtoReflect() protoreflect.Message {
+func (x *PopularCombination) ProtoReflect() protoreflect.Message {
 	mi := &file_obb_popular_proto_msgTypes[2]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -147,23 +154,30 @@ func (x *PopularCombinationMarket) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use PopularCombinationMarket.ProtoReflect.Descriptor instead.
-func (*PopularCombinationMarket) Descriptor() ([]byte, []int) {
+// Deprecated: Use PopularCombination.ProtoReflect.Descriptor instead.
+func (*PopularCombination) Descriptor() ([]byte, []int) {
 	return file_obb_popular_proto_rawDescGZIP(), []int{2}
 }
 
-func (x *PopularCombinationMarket) GetMarketId() uint32 {
+func (x *PopularCombination) GetSelectionIds() []string {
 	if x != nil {
-		return x.MarketId
+		return x.SelectionIds
+	}
+	return nil
+}
+
+func (x *PopularCombination) GetOdds() uint64 {
+	if x != nil {
+		return x.Odds
 	}
 	return 0
 }
 
-func (x *PopularCombinationMarket) GetSpecifiers() string {
+func (x *PopularCombination) GetRawProbability() float64 {
 	if x != nil {
-		return x.Specifiers
+		return x.RawProbability
 	}
-	return ""
+	return 0
 }
 
 var File_obb_popular_proto protoreflect.FileDescriptor
@@ -172,14 +186,13 @@ const file_obb_popular_proto_rawDesc = "" +
 	"\n" +
 	"\x11obb/popular.proto\x12\x03obb\"6\n" +
 	"\x19PopularCombinationRequest\x12\x19\n" +
-	"\bevent_id\x18\x01 \x01(\tR\aeventId\"U\n" +
-	"\x1aPopularCombinationResponse\x127\n" +
-	"\amarkets\x18\x01 \x03(\v2\x1d.obb.PopularCombinationMarketR\amarkets\"W\n" +
-	"\x18PopularCombinationMarket\x12\x1b\n" +
-	"\tmarket_id\x18\x01 \x01(\rR\bmarketId\x12\x1e\n" +
-	"\n" +
-	"specifiers\x18\x02 \x01(\tR\n" +
-	"specifiersB5\n" +
+	"\bevent_id\x18\x01 \x01(\tR\aeventId\"h\n" +
+	"\x1aPopularCombinationResponse\x12;\n" +
+	"\fcombinations\x18\x02 \x03(\v2\x17.obb.PopularCombinationR\fcombinationsJ\x04\b\x01\x10\x02R\amarkets\"v\n" +
+	"\x12PopularCombination\x12#\n" +
+	"\rselection_ids\x18\x01 \x03(\tR\fselectionIds\x12\x12\n" +
+	"\x04odds\x18\x02 \x01(\x04R\x04odds\x12'\n" +
+	"\x0fraw_probability\x18\x03 \x01(\x01R\x0erawProbabilityB5\n" +
 	"\rcom.oddin.obbZ$github.com/oddin-gg/obbschema/go/obbb\x06proto3"
 
 var (
@@ -198,10 +211,10 @@ var file_obb_popular_proto_msgTypes = make([]protoimpl.MessageInfo, 3)
 var file_obb_popular_proto_goTypes = []any{
 	(*PopularCombinationRequest)(nil),  // 0: obb.PopularCombinationRequest
 	(*PopularCombinationResponse)(nil), // 1: obb.PopularCombinationResponse
-	(*PopularCombinationMarket)(nil),   // 2: obb.PopularCombinationMarket
+	(*PopularCombination)(nil),         // 2: obb.PopularCombination
 }
 var file_obb_popular_proto_depIdxs = []int32{
-	2, // 0: obb.PopularCombinationResponse.markets:type_name -> obb.PopularCombinationMarket
+	2, // 0: obb.PopularCombinationResponse.combinations:type_name -> obb.PopularCombination
 	1, // [1:1] is the sub-list for method output_type
 	1, // [1:1] is the sub-list for method input_type
 	1, // [1:1] is the sub-list for extension type_name

--- a/java/src/main/java/com/oddin/obb/Popular.java
+++ b/java/src/main/java/com/oddin/obb/Popular.java
@@ -605,46 +605,51 @@ public final class Popular {
 
     /**
      * <pre>
-     * List of popular markets for OBB combinations.
+     * Popular selection combinations for the event, ready to be used
+     * in SessionCreateRequest without further processing.
      * </pre>
      *
-     * <code>repeated .obb.PopularCombinationMarket markets = 1 [json_name = "markets"];</code>
+     * <code>repeated .obb.PopularCombination combinations = 2 [json_name = "combinations"];</code>
      */
-    java.util.List<com.oddin.obb.Popular.PopularCombinationMarket> 
-        getMarketsList();
+    java.util.List<com.oddin.obb.Popular.PopularCombination> 
+        getCombinationsList();
     /**
      * <pre>
-     * List of popular markets for OBB combinations.
+     * Popular selection combinations for the event, ready to be used
+     * in SessionCreateRequest without further processing.
      * </pre>
      *
-     * <code>repeated .obb.PopularCombinationMarket markets = 1 [json_name = "markets"];</code>
+     * <code>repeated .obb.PopularCombination combinations = 2 [json_name = "combinations"];</code>
      */
-    com.oddin.obb.Popular.PopularCombinationMarket getMarkets(int index);
+    com.oddin.obb.Popular.PopularCombination getCombinations(int index);
     /**
      * <pre>
-     * List of popular markets for OBB combinations.
+     * Popular selection combinations for the event, ready to be used
+     * in SessionCreateRequest without further processing.
      * </pre>
      *
-     * <code>repeated .obb.PopularCombinationMarket markets = 1 [json_name = "markets"];</code>
+     * <code>repeated .obb.PopularCombination combinations = 2 [json_name = "combinations"];</code>
      */
-    int getMarketsCount();
+    int getCombinationsCount();
     /**
      * <pre>
-     * List of popular markets for OBB combinations.
+     * Popular selection combinations for the event, ready to be used
+     * in SessionCreateRequest without further processing.
      * </pre>
      *
-     * <code>repeated .obb.PopularCombinationMarket markets = 1 [json_name = "markets"];</code>
+     * <code>repeated .obb.PopularCombination combinations = 2 [json_name = "combinations"];</code>
      */
-    java.util.List<? extends com.oddin.obb.Popular.PopularCombinationMarketOrBuilder> 
-        getMarketsOrBuilderList();
+    java.util.List<? extends com.oddin.obb.Popular.PopularCombinationOrBuilder> 
+        getCombinationsOrBuilderList();
     /**
      * <pre>
-     * List of popular markets for OBB combinations.
+     * Popular selection combinations for the event, ready to be used
+     * in SessionCreateRequest without further processing.
      * </pre>
      *
-     * <code>repeated .obb.PopularCombinationMarket markets = 1 [json_name = "markets"];</code>
+     * <code>repeated .obb.PopularCombination combinations = 2 [json_name = "combinations"];</code>
      */
-    com.oddin.obb.Popular.PopularCombinationMarketOrBuilder getMarketsOrBuilder(
+    com.oddin.obb.Popular.PopularCombinationOrBuilder getCombinationsOrBuilder(
         int index);
   }
   /**
@@ -660,7 +665,7 @@ public final class Popular {
       super(builder);
     }
     private PopularCombinationResponse() {
-      markets_ = java.util.Collections.emptyList();
+      combinations_ = java.util.Collections.emptyList();
     }
 
     @java.lang.Override
@@ -688,64 +693,69 @@ public final class Popular {
               com.oddin.obb.Popular.PopularCombinationResponse.class, com.oddin.obb.Popular.PopularCombinationResponse.Builder.class);
     }
 
-    public static final int MARKETS_FIELD_NUMBER = 1;
-    private java.util.List<com.oddin.obb.Popular.PopularCombinationMarket> markets_;
+    public static final int COMBINATIONS_FIELD_NUMBER = 2;
+    private java.util.List<com.oddin.obb.Popular.PopularCombination> combinations_;
     /**
      * <pre>
-     * List of popular markets for OBB combinations.
+     * Popular selection combinations for the event, ready to be used
+     * in SessionCreateRequest without further processing.
      * </pre>
      *
-     * <code>repeated .obb.PopularCombinationMarket markets = 1 [json_name = "markets"];</code>
+     * <code>repeated .obb.PopularCombination combinations = 2 [json_name = "combinations"];</code>
      */
     @java.lang.Override
-    public java.util.List<com.oddin.obb.Popular.PopularCombinationMarket> getMarketsList() {
-      return markets_;
+    public java.util.List<com.oddin.obb.Popular.PopularCombination> getCombinationsList() {
+      return combinations_;
     }
     /**
      * <pre>
-     * List of popular markets for OBB combinations.
+     * Popular selection combinations for the event, ready to be used
+     * in SessionCreateRequest without further processing.
      * </pre>
      *
-     * <code>repeated .obb.PopularCombinationMarket markets = 1 [json_name = "markets"];</code>
+     * <code>repeated .obb.PopularCombination combinations = 2 [json_name = "combinations"];</code>
      */
     @java.lang.Override
-    public java.util.List<? extends com.oddin.obb.Popular.PopularCombinationMarketOrBuilder> 
-        getMarketsOrBuilderList() {
-      return markets_;
+    public java.util.List<? extends com.oddin.obb.Popular.PopularCombinationOrBuilder> 
+        getCombinationsOrBuilderList() {
+      return combinations_;
     }
     /**
      * <pre>
-     * List of popular markets for OBB combinations.
+     * Popular selection combinations for the event, ready to be used
+     * in SessionCreateRequest without further processing.
      * </pre>
      *
-     * <code>repeated .obb.PopularCombinationMarket markets = 1 [json_name = "markets"];</code>
+     * <code>repeated .obb.PopularCombination combinations = 2 [json_name = "combinations"];</code>
      */
     @java.lang.Override
-    public int getMarketsCount() {
-      return markets_.size();
+    public int getCombinationsCount() {
+      return combinations_.size();
     }
     /**
      * <pre>
-     * List of popular markets for OBB combinations.
+     * Popular selection combinations for the event, ready to be used
+     * in SessionCreateRequest without further processing.
      * </pre>
      *
-     * <code>repeated .obb.PopularCombinationMarket markets = 1 [json_name = "markets"];</code>
+     * <code>repeated .obb.PopularCombination combinations = 2 [json_name = "combinations"];</code>
      */
     @java.lang.Override
-    public com.oddin.obb.Popular.PopularCombinationMarket getMarkets(int index) {
-      return markets_.get(index);
+    public com.oddin.obb.Popular.PopularCombination getCombinations(int index) {
+      return combinations_.get(index);
     }
     /**
      * <pre>
-     * List of popular markets for OBB combinations.
+     * Popular selection combinations for the event, ready to be used
+     * in SessionCreateRequest without further processing.
      * </pre>
      *
-     * <code>repeated .obb.PopularCombinationMarket markets = 1 [json_name = "markets"];</code>
+     * <code>repeated .obb.PopularCombination combinations = 2 [json_name = "combinations"];</code>
      */
     @java.lang.Override
-    public com.oddin.obb.Popular.PopularCombinationMarketOrBuilder getMarketsOrBuilder(
+    public com.oddin.obb.Popular.PopularCombinationOrBuilder getCombinationsOrBuilder(
         int index) {
-      return markets_.get(index);
+      return combinations_.get(index);
     }
 
     private byte memoizedIsInitialized = -1;
@@ -762,8 +772,8 @@ public final class Popular {
     @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      for (int i = 0; i < markets_.size(); i++) {
-        output.writeMessage(1, markets_.get(i));
+      for (int i = 0; i < combinations_.size(); i++) {
+        output.writeMessage(2, combinations_.get(i));
       }
       getUnknownFields().writeTo(output);
     }
@@ -774,9 +784,9 @@ public final class Popular {
       if (size != -1) return size;
 
       size = 0;
-      for (int i = 0; i < markets_.size(); i++) {
+      for (int i = 0; i < combinations_.size(); i++) {
         size += com.google.protobuf.CodedOutputStream
-          .computeMessageSize(1, markets_.get(i));
+          .computeMessageSize(2, combinations_.get(i));
       }
       size += getUnknownFields().getSerializedSize();
       memoizedSize = size;
@@ -793,8 +803,8 @@ public final class Popular {
       }
       com.oddin.obb.Popular.PopularCombinationResponse other = (com.oddin.obb.Popular.PopularCombinationResponse) obj;
 
-      if (!getMarketsList()
-          .equals(other.getMarketsList())) return false;
+      if (!getCombinationsList()
+          .equals(other.getCombinationsList())) return false;
       if (!getUnknownFields().equals(other.getUnknownFields())) return false;
       return true;
     }
@@ -806,9 +816,9 @@ public final class Popular {
       }
       int hash = 41;
       hash = (19 * hash) + getDescriptor().hashCode();
-      if (getMarketsCount() > 0) {
-        hash = (37 * hash) + MARKETS_FIELD_NUMBER;
-        hash = (53 * hash) + getMarketsList().hashCode();
+      if (getCombinationsCount() > 0) {
+        hash = (37 * hash) + COMBINATIONS_FIELD_NUMBER;
+        hash = (53 * hash) + getCombinationsList().hashCode();
       }
       hash = (29 * hash) + getUnknownFields().hashCode();
       memoizedHashCode = hash;
@@ -938,11 +948,11 @@ public final class Popular {
       @java.lang.Override
       public Builder clear() {
         super.clear();
-        if (marketsBuilder_ == null) {
-          markets_ = java.util.Collections.emptyList();
+        if (combinationsBuilder_ == null) {
+          combinations_ = java.util.Collections.emptyList();
         } else {
-          markets_ = null;
-          marketsBuilder_.clear();
+          combinations_ = null;
+          combinationsBuilder_.clear();
         }
         bitField0_ = (bitField0_ & ~0x00000001);
         return this;
@@ -972,14 +982,14 @@ public final class Popular {
       public com.oddin.obb.Popular.PopularCombinationResponse buildPartial() {
         com.oddin.obb.Popular.PopularCombinationResponse result = new com.oddin.obb.Popular.PopularCombinationResponse(this);
         int from_bitField0_ = bitField0_;
-        if (marketsBuilder_ == null) {
+        if (combinationsBuilder_ == null) {
           if (((bitField0_ & 0x00000001) != 0)) {
-            markets_ = java.util.Collections.unmodifiableList(markets_);
+            combinations_ = java.util.Collections.unmodifiableList(combinations_);
             bitField0_ = (bitField0_ & ~0x00000001);
           }
-          result.markets_ = markets_;
+          result.combinations_ = combinations_;
         } else {
-          result.markets_ = marketsBuilder_.build();
+          result.combinations_ = combinationsBuilder_.build();
         }
         onBuilt();
         return result;
@@ -1029,29 +1039,29 @@ public final class Popular {
 
       public Builder mergeFrom(com.oddin.obb.Popular.PopularCombinationResponse other) {
         if (other == com.oddin.obb.Popular.PopularCombinationResponse.getDefaultInstance()) return this;
-        if (marketsBuilder_ == null) {
-          if (!other.markets_.isEmpty()) {
-            if (markets_.isEmpty()) {
-              markets_ = other.markets_;
+        if (combinationsBuilder_ == null) {
+          if (!other.combinations_.isEmpty()) {
+            if (combinations_.isEmpty()) {
+              combinations_ = other.combinations_;
               bitField0_ = (bitField0_ & ~0x00000001);
             } else {
-              ensureMarketsIsMutable();
-              markets_.addAll(other.markets_);
+              ensureCombinationsIsMutable();
+              combinations_.addAll(other.combinations_);
             }
             onChanged();
           }
         } else {
-          if (!other.markets_.isEmpty()) {
-            if (marketsBuilder_.isEmpty()) {
-              marketsBuilder_.dispose();
-              marketsBuilder_ = null;
-              markets_ = other.markets_;
+          if (!other.combinations_.isEmpty()) {
+            if (combinationsBuilder_.isEmpty()) {
+              combinationsBuilder_.dispose();
+              combinationsBuilder_ = null;
+              combinations_ = other.combinations_;
               bitField0_ = (bitField0_ & ~0x00000001);
-              marketsBuilder_ = 
+              combinationsBuilder_ = 
                 com.google.protobuf.GeneratedMessageV3.alwaysUseFieldBuilders ?
-                   getMarketsFieldBuilder() : null;
+                   getCombinationsFieldBuilder() : null;
             } else {
-              marketsBuilder_.addAllMessages(other.markets_);
+              combinationsBuilder_.addAllMessages(other.combinations_);
             }
           }
         }
@@ -1081,19 +1091,19 @@ public final class Popular {
               case 0:
                 done = true;
                 break;
-              case 10: {
-                com.oddin.obb.Popular.PopularCombinationMarket m =
+              case 18: {
+                com.oddin.obb.Popular.PopularCombination m =
                     input.readMessage(
-                        com.oddin.obb.Popular.PopularCombinationMarket.parser(),
+                        com.oddin.obb.Popular.PopularCombination.parser(),
                         extensionRegistry);
-                if (marketsBuilder_ == null) {
-                  ensureMarketsIsMutable();
-                  markets_.add(m);
+                if (combinationsBuilder_ == null) {
+                  ensureCombinationsIsMutable();
+                  combinations_.add(m);
                 } else {
-                  marketsBuilder_.addMessage(m);
+                  combinationsBuilder_.addMessage(m);
                 }
                 break;
-              } // case 10
+              } // case 18
               default: {
                 if (!super.parseUnknownField(input, extensionRegistry, tag)) {
                   done = true; // was an endgroup tag
@@ -1111,316 +1121,334 @@ public final class Popular {
       }
       private int bitField0_;
 
-      private java.util.List<com.oddin.obb.Popular.PopularCombinationMarket> markets_ =
+      private java.util.List<com.oddin.obb.Popular.PopularCombination> combinations_ =
         java.util.Collections.emptyList();
-      private void ensureMarketsIsMutable() {
+      private void ensureCombinationsIsMutable() {
         if (!((bitField0_ & 0x00000001) != 0)) {
-          markets_ = new java.util.ArrayList<com.oddin.obb.Popular.PopularCombinationMarket>(markets_);
+          combinations_ = new java.util.ArrayList<com.oddin.obb.Popular.PopularCombination>(combinations_);
           bitField0_ |= 0x00000001;
          }
       }
 
       private com.google.protobuf.RepeatedFieldBuilderV3<
-          com.oddin.obb.Popular.PopularCombinationMarket, com.oddin.obb.Popular.PopularCombinationMarket.Builder, com.oddin.obb.Popular.PopularCombinationMarketOrBuilder> marketsBuilder_;
+          com.oddin.obb.Popular.PopularCombination, com.oddin.obb.Popular.PopularCombination.Builder, com.oddin.obb.Popular.PopularCombinationOrBuilder> combinationsBuilder_;
 
       /**
        * <pre>
-       * List of popular markets for OBB combinations.
+       * Popular selection combinations for the event, ready to be used
+       * in SessionCreateRequest without further processing.
        * </pre>
        *
-       * <code>repeated .obb.PopularCombinationMarket markets = 1 [json_name = "markets"];</code>
+       * <code>repeated .obb.PopularCombination combinations = 2 [json_name = "combinations"];</code>
        */
-      public java.util.List<com.oddin.obb.Popular.PopularCombinationMarket> getMarketsList() {
-        if (marketsBuilder_ == null) {
-          return java.util.Collections.unmodifiableList(markets_);
+      public java.util.List<com.oddin.obb.Popular.PopularCombination> getCombinationsList() {
+        if (combinationsBuilder_ == null) {
+          return java.util.Collections.unmodifiableList(combinations_);
         } else {
-          return marketsBuilder_.getMessageList();
+          return combinationsBuilder_.getMessageList();
         }
       }
       /**
        * <pre>
-       * List of popular markets for OBB combinations.
+       * Popular selection combinations for the event, ready to be used
+       * in SessionCreateRequest without further processing.
        * </pre>
        *
-       * <code>repeated .obb.PopularCombinationMarket markets = 1 [json_name = "markets"];</code>
+       * <code>repeated .obb.PopularCombination combinations = 2 [json_name = "combinations"];</code>
        */
-      public int getMarketsCount() {
-        if (marketsBuilder_ == null) {
-          return markets_.size();
+      public int getCombinationsCount() {
+        if (combinationsBuilder_ == null) {
+          return combinations_.size();
         } else {
-          return marketsBuilder_.getCount();
+          return combinationsBuilder_.getCount();
         }
       }
       /**
        * <pre>
-       * List of popular markets for OBB combinations.
+       * Popular selection combinations for the event, ready to be used
+       * in SessionCreateRequest without further processing.
        * </pre>
        *
-       * <code>repeated .obb.PopularCombinationMarket markets = 1 [json_name = "markets"];</code>
+       * <code>repeated .obb.PopularCombination combinations = 2 [json_name = "combinations"];</code>
        */
-      public com.oddin.obb.Popular.PopularCombinationMarket getMarkets(int index) {
-        if (marketsBuilder_ == null) {
-          return markets_.get(index);
+      public com.oddin.obb.Popular.PopularCombination getCombinations(int index) {
+        if (combinationsBuilder_ == null) {
+          return combinations_.get(index);
         } else {
-          return marketsBuilder_.getMessage(index);
+          return combinationsBuilder_.getMessage(index);
         }
       }
       /**
        * <pre>
-       * List of popular markets for OBB combinations.
+       * Popular selection combinations for the event, ready to be used
+       * in SessionCreateRequest without further processing.
        * </pre>
        *
-       * <code>repeated .obb.PopularCombinationMarket markets = 1 [json_name = "markets"];</code>
+       * <code>repeated .obb.PopularCombination combinations = 2 [json_name = "combinations"];</code>
        */
-      public Builder setMarkets(
-          int index, com.oddin.obb.Popular.PopularCombinationMarket value) {
-        if (marketsBuilder_ == null) {
+      public Builder setCombinations(
+          int index, com.oddin.obb.Popular.PopularCombination value) {
+        if (combinationsBuilder_ == null) {
           if (value == null) {
             throw new NullPointerException();
           }
-          ensureMarketsIsMutable();
-          markets_.set(index, value);
+          ensureCombinationsIsMutable();
+          combinations_.set(index, value);
           onChanged();
         } else {
-          marketsBuilder_.setMessage(index, value);
+          combinationsBuilder_.setMessage(index, value);
         }
         return this;
       }
       /**
        * <pre>
-       * List of popular markets for OBB combinations.
+       * Popular selection combinations for the event, ready to be used
+       * in SessionCreateRequest without further processing.
        * </pre>
        *
-       * <code>repeated .obb.PopularCombinationMarket markets = 1 [json_name = "markets"];</code>
+       * <code>repeated .obb.PopularCombination combinations = 2 [json_name = "combinations"];</code>
        */
-      public Builder setMarkets(
-          int index, com.oddin.obb.Popular.PopularCombinationMarket.Builder builderForValue) {
-        if (marketsBuilder_ == null) {
-          ensureMarketsIsMutable();
-          markets_.set(index, builderForValue.build());
+      public Builder setCombinations(
+          int index, com.oddin.obb.Popular.PopularCombination.Builder builderForValue) {
+        if (combinationsBuilder_ == null) {
+          ensureCombinationsIsMutable();
+          combinations_.set(index, builderForValue.build());
           onChanged();
         } else {
-          marketsBuilder_.setMessage(index, builderForValue.build());
+          combinationsBuilder_.setMessage(index, builderForValue.build());
         }
         return this;
       }
       /**
        * <pre>
-       * List of popular markets for OBB combinations.
+       * Popular selection combinations for the event, ready to be used
+       * in SessionCreateRequest without further processing.
        * </pre>
        *
-       * <code>repeated .obb.PopularCombinationMarket markets = 1 [json_name = "markets"];</code>
+       * <code>repeated .obb.PopularCombination combinations = 2 [json_name = "combinations"];</code>
        */
-      public Builder addMarkets(com.oddin.obb.Popular.PopularCombinationMarket value) {
-        if (marketsBuilder_ == null) {
+      public Builder addCombinations(com.oddin.obb.Popular.PopularCombination value) {
+        if (combinationsBuilder_ == null) {
           if (value == null) {
             throw new NullPointerException();
           }
-          ensureMarketsIsMutable();
-          markets_.add(value);
+          ensureCombinationsIsMutable();
+          combinations_.add(value);
           onChanged();
         } else {
-          marketsBuilder_.addMessage(value);
+          combinationsBuilder_.addMessage(value);
         }
         return this;
       }
       /**
        * <pre>
-       * List of popular markets for OBB combinations.
+       * Popular selection combinations for the event, ready to be used
+       * in SessionCreateRequest without further processing.
        * </pre>
        *
-       * <code>repeated .obb.PopularCombinationMarket markets = 1 [json_name = "markets"];</code>
+       * <code>repeated .obb.PopularCombination combinations = 2 [json_name = "combinations"];</code>
        */
-      public Builder addMarkets(
-          int index, com.oddin.obb.Popular.PopularCombinationMarket value) {
-        if (marketsBuilder_ == null) {
+      public Builder addCombinations(
+          int index, com.oddin.obb.Popular.PopularCombination value) {
+        if (combinationsBuilder_ == null) {
           if (value == null) {
             throw new NullPointerException();
           }
-          ensureMarketsIsMutable();
-          markets_.add(index, value);
+          ensureCombinationsIsMutable();
+          combinations_.add(index, value);
           onChanged();
         } else {
-          marketsBuilder_.addMessage(index, value);
+          combinationsBuilder_.addMessage(index, value);
         }
         return this;
       }
       /**
        * <pre>
-       * List of popular markets for OBB combinations.
+       * Popular selection combinations for the event, ready to be used
+       * in SessionCreateRequest without further processing.
        * </pre>
        *
-       * <code>repeated .obb.PopularCombinationMarket markets = 1 [json_name = "markets"];</code>
+       * <code>repeated .obb.PopularCombination combinations = 2 [json_name = "combinations"];</code>
        */
-      public Builder addMarkets(
-          com.oddin.obb.Popular.PopularCombinationMarket.Builder builderForValue) {
-        if (marketsBuilder_ == null) {
-          ensureMarketsIsMutable();
-          markets_.add(builderForValue.build());
+      public Builder addCombinations(
+          com.oddin.obb.Popular.PopularCombination.Builder builderForValue) {
+        if (combinationsBuilder_ == null) {
+          ensureCombinationsIsMutable();
+          combinations_.add(builderForValue.build());
           onChanged();
         } else {
-          marketsBuilder_.addMessage(builderForValue.build());
+          combinationsBuilder_.addMessage(builderForValue.build());
         }
         return this;
       }
       /**
        * <pre>
-       * List of popular markets for OBB combinations.
+       * Popular selection combinations for the event, ready to be used
+       * in SessionCreateRequest without further processing.
        * </pre>
        *
-       * <code>repeated .obb.PopularCombinationMarket markets = 1 [json_name = "markets"];</code>
+       * <code>repeated .obb.PopularCombination combinations = 2 [json_name = "combinations"];</code>
        */
-      public Builder addMarkets(
-          int index, com.oddin.obb.Popular.PopularCombinationMarket.Builder builderForValue) {
-        if (marketsBuilder_ == null) {
-          ensureMarketsIsMutable();
-          markets_.add(index, builderForValue.build());
+      public Builder addCombinations(
+          int index, com.oddin.obb.Popular.PopularCombination.Builder builderForValue) {
+        if (combinationsBuilder_ == null) {
+          ensureCombinationsIsMutable();
+          combinations_.add(index, builderForValue.build());
           onChanged();
         } else {
-          marketsBuilder_.addMessage(index, builderForValue.build());
+          combinationsBuilder_.addMessage(index, builderForValue.build());
         }
         return this;
       }
       /**
        * <pre>
-       * List of popular markets for OBB combinations.
+       * Popular selection combinations for the event, ready to be used
+       * in SessionCreateRequest without further processing.
        * </pre>
        *
-       * <code>repeated .obb.PopularCombinationMarket markets = 1 [json_name = "markets"];</code>
+       * <code>repeated .obb.PopularCombination combinations = 2 [json_name = "combinations"];</code>
        */
-      public Builder addAllMarkets(
-          java.lang.Iterable<? extends com.oddin.obb.Popular.PopularCombinationMarket> values) {
-        if (marketsBuilder_ == null) {
-          ensureMarketsIsMutable();
+      public Builder addAllCombinations(
+          java.lang.Iterable<? extends com.oddin.obb.Popular.PopularCombination> values) {
+        if (combinationsBuilder_ == null) {
+          ensureCombinationsIsMutable();
           com.google.protobuf.AbstractMessageLite.Builder.addAll(
-              values, markets_);
+              values, combinations_);
           onChanged();
         } else {
-          marketsBuilder_.addAllMessages(values);
+          combinationsBuilder_.addAllMessages(values);
         }
         return this;
       }
       /**
        * <pre>
-       * List of popular markets for OBB combinations.
+       * Popular selection combinations for the event, ready to be used
+       * in SessionCreateRequest without further processing.
        * </pre>
        *
-       * <code>repeated .obb.PopularCombinationMarket markets = 1 [json_name = "markets"];</code>
+       * <code>repeated .obb.PopularCombination combinations = 2 [json_name = "combinations"];</code>
        */
-      public Builder clearMarkets() {
-        if (marketsBuilder_ == null) {
-          markets_ = java.util.Collections.emptyList();
+      public Builder clearCombinations() {
+        if (combinationsBuilder_ == null) {
+          combinations_ = java.util.Collections.emptyList();
           bitField0_ = (bitField0_ & ~0x00000001);
           onChanged();
         } else {
-          marketsBuilder_.clear();
+          combinationsBuilder_.clear();
         }
         return this;
       }
       /**
        * <pre>
-       * List of popular markets for OBB combinations.
+       * Popular selection combinations for the event, ready to be used
+       * in SessionCreateRequest without further processing.
        * </pre>
        *
-       * <code>repeated .obb.PopularCombinationMarket markets = 1 [json_name = "markets"];</code>
+       * <code>repeated .obb.PopularCombination combinations = 2 [json_name = "combinations"];</code>
        */
-      public Builder removeMarkets(int index) {
-        if (marketsBuilder_ == null) {
-          ensureMarketsIsMutable();
-          markets_.remove(index);
+      public Builder removeCombinations(int index) {
+        if (combinationsBuilder_ == null) {
+          ensureCombinationsIsMutable();
+          combinations_.remove(index);
           onChanged();
         } else {
-          marketsBuilder_.remove(index);
+          combinationsBuilder_.remove(index);
         }
         return this;
       }
       /**
        * <pre>
-       * List of popular markets for OBB combinations.
+       * Popular selection combinations for the event, ready to be used
+       * in SessionCreateRequest without further processing.
        * </pre>
        *
-       * <code>repeated .obb.PopularCombinationMarket markets = 1 [json_name = "markets"];</code>
+       * <code>repeated .obb.PopularCombination combinations = 2 [json_name = "combinations"];</code>
        */
-      public com.oddin.obb.Popular.PopularCombinationMarket.Builder getMarketsBuilder(
+      public com.oddin.obb.Popular.PopularCombination.Builder getCombinationsBuilder(
           int index) {
-        return getMarketsFieldBuilder().getBuilder(index);
+        return getCombinationsFieldBuilder().getBuilder(index);
       }
       /**
        * <pre>
-       * List of popular markets for OBB combinations.
+       * Popular selection combinations for the event, ready to be used
+       * in SessionCreateRequest without further processing.
        * </pre>
        *
-       * <code>repeated .obb.PopularCombinationMarket markets = 1 [json_name = "markets"];</code>
+       * <code>repeated .obb.PopularCombination combinations = 2 [json_name = "combinations"];</code>
        */
-      public com.oddin.obb.Popular.PopularCombinationMarketOrBuilder getMarketsOrBuilder(
+      public com.oddin.obb.Popular.PopularCombinationOrBuilder getCombinationsOrBuilder(
           int index) {
-        if (marketsBuilder_ == null) {
-          return markets_.get(index);  } else {
-          return marketsBuilder_.getMessageOrBuilder(index);
+        if (combinationsBuilder_ == null) {
+          return combinations_.get(index);  } else {
+          return combinationsBuilder_.getMessageOrBuilder(index);
         }
       }
       /**
        * <pre>
-       * List of popular markets for OBB combinations.
+       * Popular selection combinations for the event, ready to be used
+       * in SessionCreateRequest without further processing.
        * </pre>
        *
-       * <code>repeated .obb.PopularCombinationMarket markets = 1 [json_name = "markets"];</code>
+       * <code>repeated .obb.PopularCombination combinations = 2 [json_name = "combinations"];</code>
        */
-      public java.util.List<? extends com.oddin.obb.Popular.PopularCombinationMarketOrBuilder> 
-           getMarketsOrBuilderList() {
-        if (marketsBuilder_ != null) {
-          return marketsBuilder_.getMessageOrBuilderList();
+      public java.util.List<? extends com.oddin.obb.Popular.PopularCombinationOrBuilder> 
+           getCombinationsOrBuilderList() {
+        if (combinationsBuilder_ != null) {
+          return combinationsBuilder_.getMessageOrBuilderList();
         } else {
-          return java.util.Collections.unmodifiableList(markets_);
+          return java.util.Collections.unmodifiableList(combinations_);
         }
       }
       /**
        * <pre>
-       * List of popular markets for OBB combinations.
+       * Popular selection combinations for the event, ready to be used
+       * in SessionCreateRequest without further processing.
        * </pre>
        *
-       * <code>repeated .obb.PopularCombinationMarket markets = 1 [json_name = "markets"];</code>
+       * <code>repeated .obb.PopularCombination combinations = 2 [json_name = "combinations"];</code>
        */
-      public com.oddin.obb.Popular.PopularCombinationMarket.Builder addMarketsBuilder() {
-        return getMarketsFieldBuilder().addBuilder(
-            com.oddin.obb.Popular.PopularCombinationMarket.getDefaultInstance());
+      public com.oddin.obb.Popular.PopularCombination.Builder addCombinationsBuilder() {
+        return getCombinationsFieldBuilder().addBuilder(
+            com.oddin.obb.Popular.PopularCombination.getDefaultInstance());
       }
       /**
        * <pre>
-       * List of popular markets for OBB combinations.
+       * Popular selection combinations for the event, ready to be used
+       * in SessionCreateRequest without further processing.
        * </pre>
        *
-       * <code>repeated .obb.PopularCombinationMarket markets = 1 [json_name = "markets"];</code>
+       * <code>repeated .obb.PopularCombination combinations = 2 [json_name = "combinations"];</code>
        */
-      public com.oddin.obb.Popular.PopularCombinationMarket.Builder addMarketsBuilder(
+      public com.oddin.obb.Popular.PopularCombination.Builder addCombinationsBuilder(
           int index) {
-        return getMarketsFieldBuilder().addBuilder(
-            index, com.oddin.obb.Popular.PopularCombinationMarket.getDefaultInstance());
+        return getCombinationsFieldBuilder().addBuilder(
+            index, com.oddin.obb.Popular.PopularCombination.getDefaultInstance());
       }
       /**
        * <pre>
-       * List of popular markets for OBB combinations.
+       * Popular selection combinations for the event, ready to be used
+       * in SessionCreateRequest without further processing.
        * </pre>
        *
-       * <code>repeated .obb.PopularCombinationMarket markets = 1 [json_name = "markets"];</code>
+       * <code>repeated .obb.PopularCombination combinations = 2 [json_name = "combinations"];</code>
        */
-      public java.util.List<com.oddin.obb.Popular.PopularCombinationMarket.Builder> 
-           getMarketsBuilderList() {
-        return getMarketsFieldBuilder().getBuilderList();
+      public java.util.List<com.oddin.obb.Popular.PopularCombination.Builder> 
+           getCombinationsBuilderList() {
+        return getCombinationsFieldBuilder().getBuilderList();
       }
       private com.google.protobuf.RepeatedFieldBuilderV3<
-          com.oddin.obb.Popular.PopularCombinationMarket, com.oddin.obb.Popular.PopularCombinationMarket.Builder, com.oddin.obb.Popular.PopularCombinationMarketOrBuilder> 
-          getMarketsFieldBuilder() {
-        if (marketsBuilder_ == null) {
-          marketsBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
-              com.oddin.obb.Popular.PopularCombinationMarket, com.oddin.obb.Popular.PopularCombinationMarket.Builder, com.oddin.obb.Popular.PopularCombinationMarketOrBuilder>(
-                  markets_,
+          com.oddin.obb.Popular.PopularCombination, com.oddin.obb.Popular.PopularCombination.Builder, com.oddin.obb.Popular.PopularCombinationOrBuilder> 
+          getCombinationsFieldBuilder() {
+        if (combinationsBuilder_ == null) {
+          combinationsBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
+              com.oddin.obb.Popular.PopularCombination, com.oddin.obb.Popular.PopularCombination.Builder, com.oddin.obb.Popular.PopularCombinationOrBuilder>(
+                  combinations_,
                   ((bitField0_ & 0x00000001) != 0),
                   getParentForChildren(),
                   isClean());
-          markets_ = null;
+          combinations_ = null;
         }
-        return marketsBuilder_;
+        return combinationsBuilder_;
       }
       @java.lang.Override
       public final Builder setUnknownFields(
@@ -1486,63 +1514,106 @@ public final class Popular {
 
   }
 
-  public interface PopularCombinationMarketOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:obb.PopularCombinationMarket)
+  public interface PopularCombinationOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:obb.PopularCombination)
       com.google.protobuf.MessageOrBuilder {
 
     /**
      * <pre>
-     * The ID using the same values as our odds feed in XML.
+     * Selections forming the combination, in the same format as
+     * SessionCreateRequest.selection_ids:
+     * "&lt;event_id&gt;/&lt;market_id&gt;/&lt;outcome_id&gt;?&lt;market_specifier&gt;"
+     * Example: "od:match:1234/1/1?map=1&amp;way=two"
      * </pre>
      *
-     * <code>uint32 market_id = 1 [json_name = "marketId"];</code>
-     * @return The marketId.
+     * <code>repeated string selection_ids = 1 [json_name = "selectionIds"];</code>
+     * @return A list containing the selectionIds.
      */
-    int getMarketId();
+    java.util.List<java.lang.String>
+        getSelectionIdsList();
+    /**
+     * <pre>
+     * Selections forming the combination, in the same format as
+     * SessionCreateRequest.selection_ids:
+     * "&lt;event_id&gt;/&lt;market_id&gt;/&lt;outcome_id&gt;?&lt;market_specifier&gt;"
+     * Example: "od:match:1234/1/1?map=1&amp;way=two"
+     * </pre>
+     *
+     * <code>repeated string selection_ids = 1 [json_name = "selectionIds"];</code>
+     * @return The count of selectionIds.
+     */
+    int getSelectionIdsCount();
+    /**
+     * <pre>
+     * Selections forming the combination, in the same format as
+     * SessionCreateRequest.selection_ids:
+     * "&lt;event_id&gt;/&lt;market_id&gt;/&lt;outcome_id&gt;?&lt;market_specifier&gt;"
+     * Example: "od:match:1234/1/1?map=1&amp;way=two"
+     * </pre>
+     *
+     * <code>repeated string selection_ids = 1 [json_name = "selectionIds"];</code>
+     * @param index The index of the element to return.
+     * @return The selectionIds at the given index.
+     */
+    java.lang.String getSelectionIds(int index);
+    /**
+     * <pre>
+     * Selections forming the combination, in the same format as
+     * SessionCreateRequest.selection_ids:
+     * "&lt;event_id&gt;/&lt;market_id&gt;/&lt;outcome_id&gt;?&lt;market_specifier&gt;"
+     * Example: "od:match:1234/1/1?map=1&amp;way=two"
+     * </pre>
+     *
+     * <code>repeated string selection_ids = 1 [json_name = "selectionIds"];</code>
+     * @param index The index of the value to return.
+     * @return The bytes of the selectionIds at the given index.
+     */
+    com.google.protobuf.ByteString
+        getSelectionIdsBytes(int index);
 
     /**
      * <pre>
-     * The specifier is using the same values as our odds feed in XML.
-     * Example: "variant=way:three|way=three|map=1"
+     * Total odds for the whole combination.
+     * Odds multiplied by 10000 and rounded to uint value.
      * </pre>
      *
-     * <code>string specifiers = 2 [json_name = "specifiers"];</code>
-     * @return The specifiers.
+     * <code>uint64 odds = 2 [json_name = "odds"];</code>
+     * @return The odds.
      */
-    java.lang.String getSpecifiers();
+    long getOdds();
+
     /**
      * <pre>
-     * The specifier is using the same values as our odds feed in XML.
-     * Example: "variant=way:three|way=three|map=1"
+     * Raw probability of the combination (value between 0.0 and 1.0).
+     * This is the combined probability of all selections before margin is applied.
      * </pre>
      *
-     * <code>string specifiers = 2 [json_name = "specifiers"];</code>
-     * @return The bytes for specifiers.
+     * <code>double raw_probability = 3 [json_name = "rawProbability"];</code>
+     * @return The rawProbability.
      */
-    com.google.protobuf.ByteString
-        getSpecifiersBytes();
+    double getRawProbability();
   }
   /**
-   * Protobuf type {@code obb.PopularCombinationMarket}
+   * Protobuf type {@code obb.PopularCombination}
    */
-  public static final class PopularCombinationMarket extends
+  public static final class PopularCombination extends
       com.google.protobuf.GeneratedMessageV3 implements
-      // @@protoc_insertion_point(message_implements:obb.PopularCombinationMarket)
-      PopularCombinationMarketOrBuilder {
+      // @@protoc_insertion_point(message_implements:obb.PopularCombination)
+      PopularCombinationOrBuilder {
   private static final long serialVersionUID = 0L;
-    // Use PopularCombinationMarket.newBuilder() to construct.
-    private PopularCombinationMarket(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
+    // Use PopularCombination.newBuilder() to construct.
+    private PopularCombination(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
       super(builder);
     }
-    private PopularCombinationMarket() {
-      specifiers_ = "";
+    private PopularCombination() {
+      selectionIds_ = com.google.protobuf.LazyStringArrayList.EMPTY;
     }
 
     @java.lang.Override
     @SuppressWarnings({"unused"})
     protected java.lang.Object newInstance(
         UnusedPrivateParameter unused) {
-      return new PopularCombinationMarket();
+      return new PopularCombination();
     }
 
     @java.lang.Override
@@ -1552,78 +1623,110 @@ public final class Popular {
     }
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return com.oddin.obb.Popular.internal_static_obb_PopularCombinationMarket_descriptor;
+      return com.oddin.obb.Popular.internal_static_obb_PopularCombination_descriptor;
     }
 
     @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return com.oddin.obb.Popular.internal_static_obb_PopularCombinationMarket_fieldAccessorTable
+      return com.oddin.obb.Popular.internal_static_obb_PopularCombination_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
-              com.oddin.obb.Popular.PopularCombinationMarket.class, com.oddin.obb.Popular.PopularCombinationMarket.Builder.class);
+              com.oddin.obb.Popular.PopularCombination.class, com.oddin.obb.Popular.PopularCombination.Builder.class);
     }
 
-    public static final int MARKET_ID_FIELD_NUMBER = 1;
-    private int marketId_;
+    public static final int SELECTION_IDS_FIELD_NUMBER = 1;
+    private com.google.protobuf.LazyStringList selectionIds_;
     /**
      * <pre>
-     * The ID using the same values as our odds feed in XML.
+     * Selections forming the combination, in the same format as
+     * SessionCreateRequest.selection_ids:
+     * "&lt;event_id&gt;/&lt;market_id&gt;/&lt;outcome_id&gt;?&lt;market_specifier&gt;"
+     * Example: "od:match:1234/1/1?map=1&amp;way=two"
      * </pre>
      *
-     * <code>uint32 market_id = 1 [json_name = "marketId"];</code>
-     * @return The marketId.
+     * <code>repeated string selection_ids = 1 [json_name = "selectionIds"];</code>
+     * @return A list containing the selectionIds.
      */
-    @java.lang.Override
-    public int getMarketId() {
-      return marketId_;
-    }
-
-    public static final int SPECIFIERS_FIELD_NUMBER = 2;
-    private volatile java.lang.Object specifiers_;
-    /**
-     * <pre>
-     * The specifier is using the same values as our odds feed in XML.
-     * Example: "variant=way:three|way=three|map=1"
-     * </pre>
-     *
-     * <code>string specifiers = 2 [json_name = "specifiers"];</code>
-     * @return The specifiers.
-     */
-    @java.lang.Override
-    public java.lang.String getSpecifiers() {
-      java.lang.Object ref = specifiers_;
-      if (ref instanceof java.lang.String) {
-        return (java.lang.String) ref;
-      } else {
-        com.google.protobuf.ByteString bs = 
-            (com.google.protobuf.ByteString) ref;
-        java.lang.String s = bs.toStringUtf8();
-        specifiers_ = s;
-        return s;
-      }
+    public com.google.protobuf.ProtocolStringList
+        getSelectionIdsList() {
+      return selectionIds_;
     }
     /**
      * <pre>
-     * The specifier is using the same values as our odds feed in XML.
-     * Example: "variant=way:three|way=three|map=1"
+     * Selections forming the combination, in the same format as
+     * SessionCreateRequest.selection_ids:
+     * "&lt;event_id&gt;/&lt;market_id&gt;/&lt;outcome_id&gt;?&lt;market_specifier&gt;"
+     * Example: "od:match:1234/1/1?map=1&amp;way=two"
      * </pre>
      *
-     * <code>string specifiers = 2 [json_name = "specifiers"];</code>
-     * @return The bytes for specifiers.
+     * <code>repeated string selection_ids = 1 [json_name = "selectionIds"];</code>
+     * @return The count of selectionIds.
      */
-    @java.lang.Override
+    public int getSelectionIdsCount() {
+      return selectionIds_.size();
+    }
+    /**
+     * <pre>
+     * Selections forming the combination, in the same format as
+     * SessionCreateRequest.selection_ids:
+     * "&lt;event_id&gt;/&lt;market_id&gt;/&lt;outcome_id&gt;?&lt;market_specifier&gt;"
+     * Example: "od:match:1234/1/1?map=1&amp;way=two"
+     * </pre>
+     *
+     * <code>repeated string selection_ids = 1 [json_name = "selectionIds"];</code>
+     * @param index The index of the element to return.
+     * @return The selectionIds at the given index.
+     */
+    public java.lang.String getSelectionIds(int index) {
+      return selectionIds_.get(index);
+    }
+    /**
+     * <pre>
+     * Selections forming the combination, in the same format as
+     * SessionCreateRequest.selection_ids:
+     * "&lt;event_id&gt;/&lt;market_id&gt;/&lt;outcome_id&gt;?&lt;market_specifier&gt;"
+     * Example: "od:match:1234/1/1?map=1&amp;way=two"
+     * </pre>
+     *
+     * <code>repeated string selection_ids = 1 [json_name = "selectionIds"];</code>
+     * @param index The index of the value to return.
+     * @return The bytes of the selectionIds at the given index.
+     */
     public com.google.protobuf.ByteString
-        getSpecifiersBytes() {
-      java.lang.Object ref = specifiers_;
-      if (ref instanceof java.lang.String) {
-        com.google.protobuf.ByteString b = 
-            com.google.protobuf.ByteString.copyFromUtf8(
-                (java.lang.String) ref);
-        specifiers_ = b;
-        return b;
-      } else {
-        return (com.google.protobuf.ByteString) ref;
-      }
+        getSelectionIdsBytes(int index) {
+      return selectionIds_.getByteString(index);
+    }
+
+    public static final int ODDS_FIELD_NUMBER = 2;
+    private long odds_;
+    /**
+     * <pre>
+     * Total odds for the whole combination.
+     * Odds multiplied by 10000 and rounded to uint value.
+     * </pre>
+     *
+     * <code>uint64 odds = 2 [json_name = "odds"];</code>
+     * @return The odds.
+     */
+    @java.lang.Override
+    public long getOdds() {
+      return odds_;
+    }
+
+    public static final int RAW_PROBABILITY_FIELD_NUMBER = 3;
+    private double rawProbability_;
+    /**
+     * <pre>
+     * Raw probability of the combination (value between 0.0 and 1.0).
+     * This is the combined probability of all selections before margin is applied.
+     * </pre>
+     *
+     * <code>double raw_probability = 3 [json_name = "rawProbability"];</code>
+     * @return The rawProbability.
+     */
+    @java.lang.Override
+    public double getRawProbability() {
+      return rawProbability_;
     }
 
     private byte memoizedIsInitialized = -1;
@@ -1640,11 +1743,14 @@ public final class Popular {
     @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      if (marketId_ != 0) {
-        output.writeUInt32(1, marketId_);
+      for (int i = 0; i < selectionIds_.size(); i++) {
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 1, selectionIds_.getRaw(i));
       }
-      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(specifiers_)) {
-        com.google.protobuf.GeneratedMessageV3.writeString(output, 2, specifiers_);
+      if (odds_ != 0L) {
+        output.writeUInt64(2, odds_);
+      }
+      if (java.lang.Double.doubleToRawLongBits(rawProbability_) != 0) {
+        output.writeDouble(3, rawProbability_);
       }
       getUnknownFields().writeTo(output);
     }
@@ -1655,12 +1761,21 @@ public final class Popular {
       if (size != -1) return size;
 
       size = 0;
-      if (marketId_ != 0) {
-        size += com.google.protobuf.CodedOutputStream
-          .computeUInt32Size(1, marketId_);
+      {
+        int dataSize = 0;
+        for (int i = 0; i < selectionIds_.size(); i++) {
+          dataSize += computeStringSizeNoTag(selectionIds_.getRaw(i));
+        }
+        size += dataSize;
+        size += 1 * getSelectionIdsList().size();
       }
-      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(specifiers_)) {
-        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(2, specifiers_);
+      if (odds_ != 0L) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeUInt64Size(2, odds_);
+      }
+      if (java.lang.Double.doubleToRawLongBits(rawProbability_) != 0) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeDoubleSize(3, rawProbability_);
       }
       size += getUnknownFields().getSerializedSize();
       memoizedSize = size;
@@ -1672,15 +1787,18 @@ public final class Popular {
       if (obj == this) {
        return true;
       }
-      if (!(obj instanceof com.oddin.obb.Popular.PopularCombinationMarket)) {
+      if (!(obj instanceof com.oddin.obb.Popular.PopularCombination)) {
         return super.equals(obj);
       }
-      com.oddin.obb.Popular.PopularCombinationMarket other = (com.oddin.obb.Popular.PopularCombinationMarket) obj;
+      com.oddin.obb.Popular.PopularCombination other = (com.oddin.obb.Popular.PopularCombination) obj;
 
-      if (getMarketId()
-          != other.getMarketId()) return false;
-      if (!getSpecifiers()
-          .equals(other.getSpecifiers())) return false;
+      if (!getSelectionIdsList()
+          .equals(other.getSelectionIdsList())) return false;
+      if (getOdds()
+          != other.getOdds()) return false;
+      if (java.lang.Double.doubleToLongBits(getRawProbability())
+          != java.lang.Double.doubleToLongBits(
+              other.getRawProbability())) return false;
       if (!getUnknownFields().equals(other.getUnknownFields())) return false;
       return true;
     }
@@ -1692,78 +1810,84 @@ public final class Popular {
       }
       int hash = 41;
       hash = (19 * hash) + getDescriptor().hashCode();
-      hash = (37 * hash) + MARKET_ID_FIELD_NUMBER;
-      hash = (53 * hash) + getMarketId();
-      hash = (37 * hash) + SPECIFIERS_FIELD_NUMBER;
-      hash = (53 * hash) + getSpecifiers().hashCode();
+      if (getSelectionIdsCount() > 0) {
+        hash = (37 * hash) + SELECTION_IDS_FIELD_NUMBER;
+        hash = (53 * hash) + getSelectionIdsList().hashCode();
+      }
+      hash = (37 * hash) + ODDS_FIELD_NUMBER;
+      hash = (53 * hash) + com.google.protobuf.Internal.hashLong(
+          getOdds());
+      hash = (37 * hash) + RAW_PROBABILITY_FIELD_NUMBER;
+      hash = (53 * hash) + com.google.protobuf.Internal.hashLong(
+          java.lang.Double.doubleToLongBits(getRawProbability()));
       hash = (29 * hash) + getUnknownFields().hashCode();
       memoizedHashCode = hash;
       return hash;
     }
 
-    public static com.oddin.obb.Popular.PopularCombinationMarket parseFrom(
+    public static com.oddin.obb.Popular.PopularCombination parseFrom(
         java.nio.ByteBuffer data)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
-    public static com.oddin.obb.Popular.PopularCombinationMarket parseFrom(
+    public static com.oddin.obb.Popular.PopularCombination parseFrom(
         java.nio.ByteBuffer data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
-    public static com.oddin.obb.Popular.PopularCombinationMarket parseFrom(
+    public static com.oddin.obb.Popular.PopularCombination parseFrom(
         com.google.protobuf.ByteString data)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
-    public static com.oddin.obb.Popular.PopularCombinationMarket parseFrom(
+    public static com.oddin.obb.Popular.PopularCombination parseFrom(
         com.google.protobuf.ByteString data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
-    public static com.oddin.obb.Popular.PopularCombinationMarket parseFrom(byte[] data)
+    public static com.oddin.obb.Popular.PopularCombination parseFrom(byte[] data)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
-    public static com.oddin.obb.Popular.PopularCombinationMarket parseFrom(
+    public static com.oddin.obb.Popular.PopularCombination parseFrom(
         byte[] data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
-    public static com.oddin.obb.Popular.PopularCombinationMarket parseFrom(java.io.InputStream input)
+    public static com.oddin.obb.Popular.PopularCombination parseFrom(java.io.InputStream input)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input);
     }
-    public static com.oddin.obb.Popular.PopularCombinationMarket parseFrom(
+    public static com.oddin.obb.Popular.PopularCombination parseFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
-    public static com.oddin.obb.Popular.PopularCombinationMarket parseDelimitedFrom(java.io.InputStream input)
+    public static com.oddin.obb.Popular.PopularCombination parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
-    public static com.oddin.obb.Popular.PopularCombinationMarket parseDelimitedFrom(
+    public static com.oddin.obb.Popular.PopularCombination parseDelimitedFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
     }
-    public static com.oddin.obb.Popular.PopularCombinationMarket parseFrom(
+    public static com.oddin.obb.Popular.PopularCombination parseFrom(
         com.google.protobuf.CodedInputStream input)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input);
     }
-    public static com.oddin.obb.Popular.PopularCombinationMarket parseFrom(
+    public static com.oddin.obb.Popular.PopularCombination parseFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
@@ -1776,7 +1900,7 @@ public final class Popular {
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
     }
-    public static Builder newBuilder(com.oddin.obb.Popular.PopularCombinationMarket prototype) {
+    public static Builder newBuilder(com.oddin.obb.Popular.PopularCombination prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
     @java.lang.Override
@@ -1792,26 +1916,26 @@ public final class Popular {
       return builder;
     }
     /**
-     * Protobuf type {@code obb.PopularCombinationMarket}
+     * Protobuf type {@code obb.PopularCombination}
      */
     public static final class Builder extends
         com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
-        // @@protoc_insertion_point(builder_implements:obb.PopularCombinationMarket)
-        com.oddin.obb.Popular.PopularCombinationMarketOrBuilder {
+        // @@protoc_insertion_point(builder_implements:obb.PopularCombination)
+        com.oddin.obb.Popular.PopularCombinationOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
-        return com.oddin.obb.Popular.internal_static_obb_PopularCombinationMarket_descriptor;
+        return com.oddin.obb.Popular.internal_static_obb_PopularCombination_descriptor;
       }
 
       @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return com.oddin.obb.Popular.internal_static_obb_PopularCombinationMarket_fieldAccessorTable
+        return com.oddin.obb.Popular.internal_static_obb_PopularCombination_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
-                com.oddin.obb.Popular.PopularCombinationMarket.class, com.oddin.obb.Popular.PopularCombinationMarket.Builder.class);
+                com.oddin.obb.Popular.PopularCombination.class, com.oddin.obb.Popular.PopularCombination.Builder.class);
       }
 
-      // Construct using com.oddin.obb.Popular.PopularCombinationMarket.newBuilder()
+      // Construct using com.oddin.obb.Popular.PopularCombination.newBuilder()
       private Builder() {
 
       }
@@ -1824,9 +1948,11 @@ public final class Popular {
       @java.lang.Override
       public Builder clear() {
         super.clear();
-        marketId_ = 0;
+        selectionIds_ = com.google.protobuf.LazyStringArrayList.EMPTY;
+        bitField0_ = (bitField0_ & ~0x00000001);
+        odds_ = 0L;
 
-        specifiers_ = "";
+        rawProbability_ = 0D;
 
         return this;
       }
@@ -1834,17 +1960,17 @@ public final class Popular {
       @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
-        return com.oddin.obb.Popular.internal_static_obb_PopularCombinationMarket_descriptor;
+        return com.oddin.obb.Popular.internal_static_obb_PopularCombination_descriptor;
       }
 
       @java.lang.Override
-      public com.oddin.obb.Popular.PopularCombinationMarket getDefaultInstanceForType() {
-        return com.oddin.obb.Popular.PopularCombinationMarket.getDefaultInstance();
+      public com.oddin.obb.Popular.PopularCombination getDefaultInstanceForType() {
+        return com.oddin.obb.Popular.PopularCombination.getDefaultInstance();
       }
 
       @java.lang.Override
-      public com.oddin.obb.Popular.PopularCombinationMarket build() {
-        com.oddin.obb.Popular.PopularCombinationMarket result = buildPartial();
+      public com.oddin.obb.Popular.PopularCombination build() {
+        com.oddin.obb.Popular.PopularCombination result = buildPartial();
         if (!result.isInitialized()) {
           throw newUninitializedMessageException(result);
         }
@@ -1852,10 +1978,16 @@ public final class Popular {
       }
 
       @java.lang.Override
-      public com.oddin.obb.Popular.PopularCombinationMarket buildPartial() {
-        com.oddin.obb.Popular.PopularCombinationMarket result = new com.oddin.obb.Popular.PopularCombinationMarket(this);
-        result.marketId_ = marketId_;
-        result.specifiers_ = specifiers_;
+      public com.oddin.obb.Popular.PopularCombination buildPartial() {
+        com.oddin.obb.Popular.PopularCombination result = new com.oddin.obb.Popular.PopularCombination(this);
+        int from_bitField0_ = bitField0_;
+        if (((bitField0_ & 0x00000001) != 0)) {
+          selectionIds_ = selectionIds_.getUnmodifiableView();
+          bitField0_ = (bitField0_ & ~0x00000001);
+        }
+        result.selectionIds_ = selectionIds_;
+        result.odds_ = odds_;
+        result.rawProbability_ = rawProbability_;
         onBuilt();
         return result;
       }
@@ -1894,22 +2026,31 @@ public final class Popular {
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
-        if (other instanceof com.oddin.obb.Popular.PopularCombinationMarket) {
-          return mergeFrom((com.oddin.obb.Popular.PopularCombinationMarket)other);
+        if (other instanceof com.oddin.obb.Popular.PopularCombination) {
+          return mergeFrom((com.oddin.obb.Popular.PopularCombination)other);
         } else {
           super.mergeFrom(other);
           return this;
         }
       }
 
-      public Builder mergeFrom(com.oddin.obb.Popular.PopularCombinationMarket other) {
-        if (other == com.oddin.obb.Popular.PopularCombinationMarket.getDefaultInstance()) return this;
-        if (other.getMarketId() != 0) {
-          setMarketId(other.getMarketId());
-        }
-        if (!other.getSpecifiers().isEmpty()) {
-          specifiers_ = other.specifiers_;
+      public Builder mergeFrom(com.oddin.obb.Popular.PopularCombination other) {
+        if (other == com.oddin.obb.Popular.PopularCombination.getDefaultInstance()) return this;
+        if (!other.selectionIds_.isEmpty()) {
+          if (selectionIds_.isEmpty()) {
+            selectionIds_ = other.selectionIds_;
+            bitField0_ = (bitField0_ & ~0x00000001);
+          } else {
+            ensureSelectionIdsIsMutable();
+            selectionIds_.addAll(other.selectionIds_);
+          }
           onChanged();
+        }
+        if (other.getOdds() != 0L) {
+          setOdds(other.getOdds());
+        }
+        if (other.getRawProbability() != 0D) {
+          setRawProbability(other.getRawProbability());
         }
         this.mergeUnknownFields(other.getUnknownFields());
         onChanged();
@@ -1937,16 +2078,22 @@ public final class Popular {
               case 0:
                 done = true;
                 break;
-              case 8: {
-                marketId_ = input.readUInt32();
+              case 10: {
+                java.lang.String s = input.readStringRequireUtf8();
+                ensureSelectionIdsIsMutable();
+                selectionIds_.add(s);
+                break;
+              } // case 10
+              case 16: {
+                odds_ = input.readUInt64();
 
                 break;
-              } // case 8
-              case 18: {
-                specifiers_ = input.readStringRequireUtf8();
+              } // case 16
+              case 25: {
+                rawProbability_ = input.readDouble();
 
                 break;
-              } // case 18
+              } // case 25
               default: {
                 if (!super.parseUnknownField(input, extensionRegistry, tag)) {
                   done = true; // was an endgroup tag
@@ -1962,147 +2109,269 @@ public final class Popular {
         } // finally
         return this;
       }
+      private int bitField0_;
 
-      private int marketId_ ;
-      /**
-       * <pre>
-       * The ID using the same values as our odds feed in XML.
-       * </pre>
-       *
-       * <code>uint32 market_id = 1 [json_name = "marketId"];</code>
-       * @return The marketId.
-       */
-      @java.lang.Override
-      public int getMarketId() {
-        return marketId_;
+      private com.google.protobuf.LazyStringList selectionIds_ = com.google.protobuf.LazyStringArrayList.EMPTY;
+      private void ensureSelectionIdsIsMutable() {
+        if (!((bitField0_ & 0x00000001) != 0)) {
+          selectionIds_ = new com.google.protobuf.LazyStringArrayList(selectionIds_);
+          bitField0_ |= 0x00000001;
+         }
       }
       /**
        * <pre>
-       * The ID using the same values as our odds feed in XML.
+       * Selections forming the combination, in the same format as
+       * SessionCreateRequest.selection_ids:
+       * "&lt;event_id&gt;/&lt;market_id&gt;/&lt;outcome_id&gt;?&lt;market_specifier&gt;"
+       * Example: "od:match:1234/1/1?map=1&amp;way=two"
        * </pre>
        *
-       * <code>uint32 market_id = 1 [json_name = "marketId"];</code>
-       * @param value The marketId to set.
-       * @return This builder for chaining.
+       * <code>repeated string selection_ids = 1 [json_name = "selectionIds"];</code>
+       * @return A list containing the selectionIds.
        */
-      public Builder setMarketId(int value) {
-        
-        marketId_ = value;
-        onChanged();
-        return this;
+      public com.google.protobuf.ProtocolStringList
+          getSelectionIdsList() {
+        return selectionIds_.getUnmodifiableView();
       }
       /**
        * <pre>
-       * The ID using the same values as our odds feed in XML.
+       * Selections forming the combination, in the same format as
+       * SessionCreateRequest.selection_ids:
+       * "&lt;event_id&gt;/&lt;market_id&gt;/&lt;outcome_id&gt;?&lt;market_specifier&gt;"
+       * Example: "od:match:1234/1/1?map=1&amp;way=two"
        * </pre>
        *
-       * <code>uint32 market_id = 1 [json_name = "marketId"];</code>
-       * @return This builder for chaining.
+       * <code>repeated string selection_ids = 1 [json_name = "selectionIds"];</code>
+       * @return The count of selectionIds.
        */
-      public Builder clearMarketId() {
-        
-        marketId_ = 0;
-        onChanged();
-        return this;
-      }
-
-      private java.lang.Object specifiers_ = "";
-      /**
-       * <pre>
-       * The specifier is using the same values as our odds feed in XML.
-       * Example: "variant=way:three|way=three|map=1"
-       * </pre>
-       *
-       * <code>string specifiers = 2 [json_name = "specifiers"];</code>
-       * @return The specifiers.
-       */
-      public java.lang.String getSpecifiers() {
-        java.lang.Object ref = specifiers_;
-        if (!(ref instanceof java.lang.String)) {
-          com.google.protobuf.ByteString bs =
-              (com.google.protobuf.ByteString) ref;
-          java.lang.String s = bs.toStringUtf8();
-          specifiers_ = s;
-          return s;
-        } else {
-          return (java.lang.String) ref;
-        }
+      public int getSelectionIdsCount() {
+        return selectionIds_.size();
       }
       /**
        * <pre>
-       * The specifier is using the same values as our odds feed in XML.
-       * Example: "variant=way:three|way=three|map=1"
+       * Selections forming the combination, in the same format as
+       * SessionCreateRequest.selection_ids:
+       * "&lt;event_id&gt;/&lt;market_id&gt;/&lt;outcome_id&gt;?&lt;market_specifier&gt;"
+       * Example: "od:match:1234/1/1?map=1&amp;way=two"
        * </pre>
        *
-       * <code>string specifiers = 2 [json_name = "specifiers"];</code>
-       * @return The bytes for specifiers.
+       * <code>repeated string selection_ids = 1 [json_name = "selectionIds"];</code>
+       * @param index The index of the element to return.
+       * @return The selectionIds at the given index.
+       */
+      public java.lang.String getSelectionIds(int index) {
+        return selectionIds_.get(index);
+      }
+      /**
+       * <pre>
+       * Selections forming the combination, in the same format as
+       * SessionCreateRequest.selection_ids:
+       * "&lt;event_id&gt;/&lt;market_id&gt;/&lt;outcome_id&gt;?&lt;market_specifier&gt;"
+       * Example: "od:match:1234/1/1?map=1&amp;way=two"
+       * </pre>
+       *
+       * <code>repeated string selection_ids = 1 [json_name = "selectionIds"];</code>
+       * @param index The index of the value to return.
+       * @return The bytes of the selectionIds at the given index.
        */
       public com.google.protobuf.ByteString
-          getSpecifiersBytes() {
-        java.lang.Object ref = specifiers_;
-        if (ref instanceof String) {
-          com.google.protobuf.ByteString b = 
-              com.google.protobuf.ByteString.copyFromUtf8(
-                  (java.lang.String) ref);
-          specifiers_ = b;
-          return b;
-        } else {
-          return (com.google.protobuf.ByteString) ref;
-        }
+          getSelectionIdsBytes(int index) {
+        return selectionIds_.getByteString(index);
       }
       /**
        * <pre>
-       * The specifier is using the same values as our odds feed in XML.
-       * Example: "variant=way:three|way=three|map=1"
+       * Selections forming the combination, in the same format as
+       * SessionCreateRequest.selection_ids:
+       * "&lt;event_id&gt;/&lt;market_id&gt;/&lt;outcome_id&gt;?&lt;market_specifier&gt;"
+       * Example: "od:match:1234/1/1?map=1&amp;way=two"
        * </pre>
        *
-       * <code>string specifiers = 2 [json_name = "specifiers"];</code>
-       * @param value The specifiers to set.
+       * <code>repeated string selection_ids = 1 [json_name = "selectionIds"];</code>
+       * @param index The index to set the value at.
+       * @param value The selectionIds to set.
        * @return This builder for chaining.
        */
-      public Builder setSpecifiers(
+      public Builder setSelectionIds(
+          int index, java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  ensureSelectionIdsIsMutable();
+        selectionIds_.set(index, value);
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * Selections forming the combination, in the same format as
+       * SessionCreateRequest.selection_ids:
+       * "&lt;event_id&gt;/&lt;market_id&gt;/&lt;outcome_id&gt;?&lt;market_specifier&gt;"
+       * Example: "od:match:1234/1/1?map=1&amp;way=two"
+       * </pre>
+       *
+       * <code>repeated string selection_ids = 1 [json_name = "selectionIds"];</code>
+       * @param value The selectionIds to add.
+       * @return This builder for chaining.
+       */
+      public Builder addSelectionIds(
           java.lang.String value) {
         if (value == null) {
     throw new NullPointerException();
   }
-  
-        specifiers_ = value;
+  ensureSelectionIdsIsMutable();
+        selectionIds_.add(value);
         onChanged();
         return this;
       }
       /**
        * <pre>
-       * The specifier is using the same values as our odds feed in XML.
-       * Example: "variant=way:three|way=three|map=1"
+       * Selections forming the combination, in the same format as
+       * SessionCreateRequest.selection_ids:
+       * "&lt;event_id&gt;/&lt;market_id&gt;/&lt;outcome_id&gt;?&lt;market_specifier&gt;"
+       * Example: "od:match:1234/1/1?map=1&amp;way=two"
        * </pre>
        *
-       * <code>string specifiers = 2 [json_name = "specifiers"];</code>
+       * <code>repeated string selection_ids = 1 [json_name = "selectionIds"];</code>
+       * @param values The selectionIds to add.
        * @return This builder for chaining.
        */
-      public Builder clearSpecifiers() {
-        
-        specifiers_ = getDefaultInstance().getSpecifiers();
+      public Builder addAllSelectionIds(
+          java.lang.Iterable<java.lang.String> values) {
+        ensureSelectionIdsIsMutable();
+        com.google.protobuf.AbstractMessageLite.Builder.addAll(
+            values, selectionIds_);
         onChanged();
         return this;
       }
       /**
        * <pre>
-       * The specifier is using the same values as our odds feed in XML.
-       * Example: "variant=way:three|way=three|map=1"
+       * Selections forming the combination, in the same format as
+       * SessionCreateRequest.selection_ids:
+       * "&lt;event_id&gt;/&lt;market_id&gt;/&lt;outcome_id&gt;?&lt;market_specifier&gt;"
+       * Example: "od:match:1234/1/1?map=1&amp;way=two"
        * </pre>
        *
-       * <code>string specifiers = 2 [json_name = "specifiers"];</code>
-       * @param value The bytes for specifiers to set.
+       * <code>repeated string selection_ids = 1 [json_name = "selectionIds"];</code>
        * @return This builder for chaining.
        */
-      public Builder setSpecifiersBytes(
+      public Builder clearSelectionIds() {
+        selectionIds_ = com.google.protobuf.LazyStringArrayList.EMPTY;
+        bitField0_ = (bitField0_ & ~0x00000001);
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * Selections forming the combination, in the same format as
+       * SessionCreateRequest.selection_ids:
+       * "&lt;event_id&gt;/&lt;market_id&gt;/&lt;outcome_id&gt;?&lt;market_specifier&gt;"
+       * Example: "od:match:1234/1/1?map=1&amp;way=two"
+       * </pre>
+       *
+       * <code>repeated string selection_ids = 1 [json_name = "selectionIds"];</code>
+       * @param value The bytes of the selectionIds to add.
+       * @return This builder for chaining.
+       */
+      public Builder addSelectionIdsBytes(
           com.google.protobuf.ByteString value) {
         if (value == null) {
     throw new NullPointerException();
   }
   checkByteStringIsUtf8(value);
+        ensureSelectionIdsIsMutable();
+        selectionIds_.add(value);
+        onChanged();
+        return this;
+      }
+
+      private long odds_ ;
+      /**
+       * <pre>
+       * Total odds for the whole combination.
+       * Odds multiplied by 10000 and rounded to uint value.
+       * </pre>
+       *
+       * <code>uint64 odds = 2 [json_name = "odds"];</code>
+       * @return The odds.
+       */
+      @java.lang.Override
+      public long getOdds() {
+        return odds_;
+      }
+      /**
+       * <pre>
+       * Total odds for the whole combination.
+       * Odds multiplied by 10000 and rounded to uint value.
+       * </pre>
+       *
+       * <code>uint64 odds = 2 [json_name = "odds"];</code>
+       * @param value The odds to set.
+       * @return This builder for chaining.
+       */
+      public Builder setOdds(long value) {
         
-        specifiers_ = value;
+        odds_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * Total odds for the whole combination.
+       * Odds multiplied by 10000 and rounded to uint value.
+       * </pre>
+       *
+       * <code>uint64 odds = 2 [json_name = "odds"];</code>
+       * @return This builder for chaining.
+       */
+      public Builder clearOdds() {
+        
+        odds_ = 0L;
+        onChanged();
+        return this;
+      }
+
+      private double rawProbability_ ;
+      /**
+       * <pre>
+       * Raw probability of the combination (value between 0.0 and 1.0).
+       * This is the combined probability of all selections before margin is applied.
+       * </pre>
+       *
+       * <code>double raw_probability = 3 [json_name = "rawProbability"];</code>
+       * @return The rawProbability.
+       */
+      @java.lang.Override
+      public double getRawProbability() {
+        return rawProbability_;
+      }
+      /**
+       * <pre>
+       * Raw probability of the combination (value between 0.0 and 1.0).
+       * This is the combined probability of all selections before margin is applied.
+       * </pre>
+       *
+       * <code>double raw_probability = 3 [json_name = "rawProbability"];</code>
+       * @param value The rawProbability to set.
+       * @return This builder for chaining.
+       */
+      public Builder setRawProbability(double value) {
+        
+        rawProbability_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * Raw probability of the combination (value between 0.0 and 1.0).
+       * This is the combined probability of all selections before margin is applied.
+       * </pre>
+       *
+       * <code>double raw_probability = 3 [json_name = "rawProbability"];</code>
+       * @return This builder for chaining.
+       */
+      public Builder clearRawProbability() {
+        
+        rawProbability_ = 0D;
         onChanged();
         return this;
       }
@@ -2119,23 +2388,23 @@ public final class Popular {
       }
 
 
-      // @@protoc_insertion_point(builder_scope:obb.PopularCombinationMarket)
+      // @@protoc_insertion_point(builder_scope:obb.PopularCombination)
     }
 
-    // @@protoc_insertion_point(class_scope:obb.PopularCombinationMarket)
-    private static final com.oddin.obb.Popular.PopularCombinationMarket DEFAULT_INSTANCE;
+    // @@protoc_insertion_point(class_scope:obb.PopularCombination)
+    private static final com.oddin.obb.Popular.PopularCombination DEFAULT_INSTANCE;
     static {
-      DEFAULT_INSTANCE = new com.oddin.obb.Popular.PopularCombinationMarket();
+      DEFAULT_INSTANCE = new com.oddin.obb.Popular.PopularCombination();
     }
 
-    public static com.oddin.obb.Popular.PopularCombinationMarket getDefaultInstance() {
+    public static com.oddin.obb.Popular.PopularCombination getDefaultInstance() {
       return DEFAULT_INSTANCE;
     }
 
-    private static final com.google.protobuf.Parser<PopularCombinationMarket>
-        PARSER = new com.google.protobuf.AbstractParser<PopularCombinationMarket>() {
+    private static final com.google.protobuf.Parser<PopularCombination>
+        PARSER = new com.google.protobuf.AbstractParser<PopularCombination>() {
       @java.lang.Override
-      public PopularCombinationMarket parsePartialFrom(
+      public PopularCombination parsePartialFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
@@ -2154,17 +2423,17 @@ public final class Popular {
       }
     };
 
-    public static com.google.protobuf.Parser<PopularCombinationMarket> parser() {
+    public static com.google.protobuf.Parser<PopularCombination> parser() {
       return PARSER;
     }
 
     @java.lang.Override
-    public com.google.protobuf.Parser<PopularCombinationMarket> getParserForType() {
+    public com.google.protobuf.Parser<PopularCombination> getParserForType() {
       return PARSER;
     }
 
     @java.lang.Override
-    public com.oddin.obb.Popular.PopularCombinationMarket getDefaultInstanceForType() {
+    public com.oddin.obb.Popular.PopularCombination getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
 
@@ -2181,10 +2450,10 @@ public final class Popular {
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_obb_PopularCombinationResponse_fieldAccessorTable;
   private static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_obb_PopularCombinationMarket_descriptor;
+    internal_static_obb_PopularCombination_descriptor;
   private static final 
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
-      internal_static_obb_PopularCombinationMarket_fieldAccessorTable;
+      internal_static_obb_PopularCombination_fieldAccessorTable;
 
   public static com.google.protobuf.Descriptors.FileDescriptor
       getDescriptor() {
@@ -2196,12 +2465,14 @@ public final class Popular {
     java.lang.String[] descriptorData = {
       "\n\021obb/popular.proto\022\003obb\"6\n\031PopularCombi" +
       "nationRequest\022\031\n\010event_id\030\001 \001(\tR\007eventId" +
-      "\"U\n\032PopularCombinationResponse\0227\n\007market" +
-      "s\030\001 \003(\0132\035.obb.PopularCombinationMarketR\007" +
-      "markets\"W\n\030PopularCombinationMarket\022\033\n\tm" +
-      "arket_id\030\001 \001(\rR\010marketId\022\036\n\nspecifiers\030\002" +
-      " \001(\tR\nspecifiersB5\n\rcom.oddin.obbZ$githu" +
-      "b.com/oddin-gg/obbschema/go/obbb\006proto3"
+      "\"h\n\032PopularCombinationResponse\022;\n\014combin" +
+      "ations\030\002 \003(\0132\027.obb.PopularCombinationR\014c" +
+      "ombinationsJ\004\010\001\020\002R\007markets\"v\n\022PopularCom" +
+      "bination\022#\n\rselection_ids\030\001 \003(\tR\014selecti" +
+      "onIds\022\022\n\004odds\030\002 \001(\004R\004odds\022\'\n\017raw_probabi" +
+      "lity\030\003 \001(\001R\016rawProbabilityB5\n\rcom.oddin." +
+      "obbZ$github.com/oddin-gg/obbschema/go/ob" +
+      "bb\006proto3"
     };
     descriptor = com.google.protobuf.Descriptors.FileDescriptor
       .internalBuildGeneratedFileFrom(descriptorData,
@@ -2218,13 +2489,13 @@ public final class Popular {
     internal_static_obb_PopularCombinationResponse_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_obb_PopularCombinationResponse_descriptor,
-        new java.lang.String[] { "Markets", });
-    internal_static_obb_PopularCombinationMarket_descriptor =
+        new java.lang.String[] { "Combinations", });
+    internal_static_obb_PopularCombination_descriptor =
       getDescriptor().getMessageTypes().get(2);
-    internal_static_obb_PopularCombinationMarket_fieldAccessorTable = new
+    internal_static_obb_PopularCombination_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_obb_PopularCombinationMarket_descriptor,
-        new java.lang.String[] { "MarketId", "Specifiers", });
+        internal_static_obb_PopularCombination_descriptor,
+        new java.lang.String[] { "SelectionIds", "Odds", "RawProbability", });
   }
 
   // @@protoc_insertion_point(outer_class_scope)

--- a/js/obb/popular_pb.d.ts
+++ b/js/obb/popular_pb.d.ts
@@ -24,10 +24,10 @@ export namespace PopularCombinationRequest {
 }
 
 export class PopularCombinationResponse extends jspb.Message {
-  clearMarketsList(): void;
-  getMarketsList(): Array<PopularCombinationMarket>;
-  setMarketsList(value: Array<PopularCombinationMarket>): void;
-  addMarkets(value?: PopularCombinationMarket, index?: number): PopularCombinationMarket;
+  clearCombinationsList(): void;
+  getCombinationsList(): Array<PopularCombination>;
+  setCombinationsList(value: Array<PopularCombination>): void;
+  addCombinations(value?: PopularCombination, index?: number): PopularCombination;
 
   serializeBinary(): Uint8Array;
   toObject(includeInstance?: boolean): PopularCombinationResponse.AsObject;
@@ -41,31 +41,37 @@ export class PopularCombinationResponse extends jspb.Message {
 
 export namespace PopularCombinationResponse {
   export type AsObject = {
-    marketsList: Array<PopularCombinationMarket.AsObject>,
+    combinationsList: Array<PopularCombination.AsObject>,
   }
 }
 
-export class PopularCombinationMarket extends jspb.Message {
-  getMarketId(): number;
-  setMarketId(value: number): void;
+export class PopularCombination extends jspb.Message {
+  clearSelectionIdsList(): void;
+  getSelectionIdsList(): Array<string>;
+  setSelectionIdsList(value: Array<string>): void;
+  addSelectionIds(value: string, index?: number): string;
 
-  getSpecifiers(): string;
-  setSpecifiers(value: string): void;
+  getOdds(): number;
+  setOdds(value: number): void;
+
+  getRawProbability(): number;
+  setRawProbability(value: number): void;
 
   serializeBinary(): Uint8Array;
-  toObject(includeInstance?: boolean): PopularCombinationMarket.AsObject;
-  static toObject(includeInstance: boolean, msg: PopularCombinationMarket): PopularCombinationMarket.AsObject;
+  toObject(includeInstance?: boolean): PopularCombination.AsObject;
+  static toObject(includeInstance: boolean, msg: PopularCombination): PopularCombination.AsObject;
   static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
   static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-  static serializeBinaryToWriter(message: PopularCombinationMarket, writer: jspb.BinaryWriter): void;
-  static deserializeBinary(bytes: Uint8Array): PopularCombinationMarket;
-  static deserializeBinaryFromReader(message: PopularCombinationMarket, reader: jspb.BinaryReader): PopularCombinationMarket;
+  static serializeBinaryToWriter(message: PopularCombination, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): PopularCombination;
+  static deserializeBinaryFromReader(message: PopularCombination, reader: jspb.BinaryReader): PopularCombination;
 }
 
-export namespace PopularCombinationMarket {
+export namespace PopularCombination {
   export type AsObject = {
-    marketId: number,
-    specifiers: string,
+    selectionIdsList: Array<string>,
+    odds: number,
+    rawProbability: number,
   }
 }
 

--- a/js/obb/popular_pb.js
+++ b/js/obb/popular_pb.js
@@ -21,7 +21,7 @@ var global = (function() {
   return Function('return this')();
 }.call(null));
 
-goog.exportSymbol('proto.obb.PopularCombinationMarket', null, global);
+goog.exportSymbol('proto.obb.PopularCombination', null, global);
 goog.exportSymbol('proto.obb.PopularCombinationRequest', null, global);
 goog.exportSymbol('proto.obb.PopularCombinationResponse', null, global);
 /**
@@ -76,16 +76,16 @@ if (goog.DEBUG && !COMPILED) {
  * @extends {jspb.Message}
  * @constructor
  */
-proto.obb.PopularCombinationMarket = function(opt_data) {
-  jspb.Message.initialize(this, opt_data, 0, -1, null, null);
+proto.obb.PopularCombination = function(opt_data) {
+  jspb.Message.initialize(this, opt_data, 0, -1, proto.obb.PopularCombination.repeatedFields_, null);
 };
-goog.inherits(proto.obb.PopularCombinationMarket, jspb.Message);
+goog.inherits(proto.obb.PopularCombination, jspb.Message);
 if (goog.DEBUG && !COMPILED) {
   /**
    * @public
    * @override
    */
-  proto.obb.PopularCombinationMarket.displayName = 'proto.obb.PopularCombinationMarket';
+  proto.obb.PopularCombination.displayName = 'proto.obb.PopularCombination';
 }
 
 
@@ -223,7 +223,7 @@ proto.obb.PopularCombinationRequest.prototype.setEventId = function(value) {
  * @private {!Array<number>}
  * @const
  */
-proto.obb.PopularCombinationResponse.repeatedFields_ = [1];
+proto.obb.PopularCombinationResponse.repeatedFields_ = [2];
 
 
 
@@ -256,8 +256,8 @@ proto.obb.PopularCombinationResponse.prototype.toObject = function(opt_includeIn
  */
 proto.obb.PopularCombinationResponse.toObject = function(includeInstance, msg) {
   var f, obj = {
-    marketsList: jspb.Message.toObjectList(msg.getMarketsList(),
-    proto.obb.PopularCombinationMarket.toObject, includeInstance)
+    combinationsList: jspb.Message.toObjectList(msg.getCombinationsList(),
+    proto.obb.PopularCombination.toObject, includeInstance)
   };
 
   if (includeInstance) {
@@ -294,10 +294,10 @@ proto.obb.PopularCombinationResponse.deserializeBinaryFromReader = function(msg,
     }
     var field = reader.getFieldNumber();
     switch (field) {
-    case 1:
-      var value = new proto.obb.PopularCombinationMarket;
-      reader.readMessage(value,proto.obb.PopularCombinationMarket.deserializeBinaryFromReader);
-      msg.addMarkets(value);
+    case 2:
+      var value = new proto.obb.PopularCombination;
+      reader.readMessage(value,proto.obb.PopularCombination.deserializeBinaryFromReader);
+      msg.addCombinations(value);
       break;
     default:
       reader.skipField();
@@ -328,43 +328,43 @@ proto.obb.PopularCombinationResponse.prototype.serializeBinary = function() {
  */
 proto.obb.PopularCombinationResponse.serializeBinaryToWriter = function(message, writer) {
   var f = undefined;
-  f = message.getMarketsList();
+  f = message.getCombinationsList();
   if (f.length > 0) {
     writer.writeRepeatedMessage(
-      1,
+      2,
       f,
-      proto.obb.PopularCombinationMarket.serializeBinaryToWriter
+      proto.obb.PopularCombination.serializeBinaryToWriter
     );
   }
 };
 
 
 /**
- * repeated PopularCombinationMarket markets = 1;
- * @return {!Array<!proto.obb.PopularCombinationMarket>}
+ * repeated PopularCombination combinations = 2;
+ * @return {!Array<!proto.obb.PopularCombination>}
  */
-proto.obb.PopularCombinationResponse.prototype.getMarketsList = function() {
-  return /** @type{!Array<!proto.obb.PopularCombinationMarket>} */ (
-    jspb.Message.getRepeatedWrapperField(this, proto.obb.PopularCombinationMarket, 1));
+proto.obb.PopularCombinationResponse.prototype.getCombinationsList = function() {
+  return /** @type{!Array<!proto.obb.PopularCombination>} */ (
+    jspb.Message.getRepeatedWrapperField(this, proto.obb.PopularCombination, 2));
 };
 
 
 /**
- * @param {!Array<!proto.obb.PopularCombinationMarket>} value
+ * @param {!Array<!proto.obb.PopularCombination>} value
  * @return {!proto.obb.PopularCombinationResponse} returns this
 */
-proto.obb.PopularCombinationResponse.prototype.setMarketsList = function(value) {
-  return jspb.Message.setRepeatedWrapperField(this, 1, value);
+proto.obb.PopularCombinationResponse.prototype.setCombinationsList = function(value) {
+  return jspb.Message.setRepeatedWrapperField(this, 2, value);
 };
 
 
 /**
- * @param {!proto.obb.PopularCombinationMarket=} opt_value
+ * @param {!proto.obb.PopularCombination=} opt_value
  * @param {number=} opt_index
- * @return {!proto.obb.PopularCombinationMarket}
+ * @return {!proto.obb.PopularCombination}
  */
-proto.obb.PopularCombinationResponse.prototype.addMarkets = function(opt_value, opt_index) {
-  return jspb.Message.addToRepeatedWrapperField(this, 1, opt_value, proto.obb.PopularCombinationMarket, opt_index);
+proto.obb.PopularCombinationResponse.prototype.addCombinations = function(opt_value, opt_index) {
+  return jspb.Message.addToRepeatedWrapperField(this, 2, opt_value, proto.obb.PopularCombination, opt_index);
 };
 
 
@@ -372,11 +372,18 @@ proto.obb.PopularCombinationResponse.prototype.addMarkets = function(opt_value, 
  * Clears the list making it empty but non-null.
  * @return {!proto.obb.PopularCombinationResponse} returns this
  */
-proto.obb.PopularCombinationResponse.prototype.clearMarketsList = function() {
-  return this.setMarketsList([]);
+proto.obb.PopularCombinationResponse.prototype.clearCombinationsList = function() {
+  return this.setCombinationsList([]);
 };
 
 
+
+/**
+ * List of repeated fields within this message type.
+ * @private {!Array<number>}
+ * @const
+ */
+proto.obb.PopularCombination.repeatedFields_ = [1];
 
 
 
@@ -393,8 +400,8 @@ if (jspb.Message.GENERATE_TO_OBJECT) {
  *     http://goto/soy-param-migration
  * @return {!Object}
  */
-proto.obb.PopularCombinationMarket.prototype.toObject = function(opt_includeInstance) {
-  return proto.obb.PopularCombinationMarket.toObject(opt_includeInstance, this);
+proto.obb.PopularCombination.prototype.toObject = function(opt_includeInstance) {
+  return proto.obb.PopularCombination.toObject(opt_includeInstance, this);
 };
 
 
@@ -403,14 +410,15 @@ proto.obb.PopularCombinationMarket.prototype.toObject = function(opt_includeInst
  * @param {boolean|undefined} includeInstance Deprecated. Whether to include
  *     the JSPB instance for transitional soy proto support:
  *     http://goto/soy-param-migration
- * @param {!proto.obb.PopularCombinationMarket} msg The msg instance to transform.
+ * @param {!proto.obb.PopularCombination} msg The msg instance to transform.
  * @return {!Object}
  * @suppress {unusedLocalVariables} f is only used for nested messages
  */
-proto.obb.PopularCombinationMarket.toObject = function(includeInstance, msg) {
+proto.obb.PopularCombination.toObject = function(includeInstance, msg) {
   var f, obj = {
-    marketId: jspb.Message.getFieldWithDefault(msg, 1, 0),
-    specifiers: jspb.Message.getFieldWithDefault(msg, 2, "")
+    selectionIdsList: (f = jspb.Message.getRepeatedField(msg, 1)) == null ? undefined : f,
+    odds: jspb.Message.getFieldWithDefault(msg, 2, 0),
+    rawProbability: jspb.Message.getFloatingPointFieldWithDefault(msg, 3, 0.0)
   };
 
   if (includeInstance) {
@@ -424,23 +432,23 @@ proto.obb.PopularCombinationMarket.toObject = function(includeInstance, msg) {
 /**
  * Deserializes binary data (in protobuf wire format).
  * @param {jspb.ByteSource} bytes The bytes to deserialize.
- * @return {!proto.obb.PopularCombinationMarket}
+ * @return {!proto.obb.PopularCombination}
  */
-proto.obb.PopularCombinationMarket.deserializeBinary = function(bytes) {
+proto.obb.PopularCombination.deserializeBinary = function(bytes) {
   var reader = new jspb.BinaryReader(bytes);
-  var msg = new proto.obb.PopularCombinationMarket;
-  return proto.obb.PopularCombinationMarket.deserializeBinaryFromReader(msg, reader);
+  var msg = new proto.obb.PopularCombination;
+  return proto.obb.PopularCombination.deserializeBinaryFromReader(msg, reader);
 };
 
 
 /**
  * Deserializes binary data (in protobuf wire format) from the
  * given reader into the given message object.
- * @param {!proto.obb.PopularCombinationMarket} msg The message object to deserialize into.
+ * @param {!proto.obb.PopularCombination} msg The message object to deserialize into.
  * @param {!jspb.BinaryReader} reader The BinaryReader to use.
- * @return {!proto.obb.PopularCombinationMarket}
+ * @return {!proto.obb.PopularCombination}
  */
-proto.obb.PopularCombinationMarket.deserializeBinaryFromReader = function(msg, reader) {
+proto.obb.PopularCombination.deserializeBinaryFromReader = function(msg, reader) {
   while (reader.nextField()) {
     if (reader.isEndGroup()) {
       break;
@@ -448,12 +456,16 @@ proto.obb.PopularCombinationMarket.deserializeBinaryFromReader = function(msg, r
     var field = reader.getFieldNumber();
     switch (field) {
     case 1:
-      var value = /** @type {number} */ (reader.readUint32());
-      msg.setMarketId(value);
+      var value = /** @type {string} */ (reader.readString());
+      msg.addSelectionIds(value);
       break;
     case 2:
-      var value = /** @type {string} */ (reader.readString());
-      msg.setSpecifiers(value);
+      var value = /** @type {number} */ (reader.readUint64());
+      msg.setOdds(value);
+      break;
+    case 3:
+      var value = /** @type {number} */ (reader.readDouble());
+      msg.setRawProbability(value);
       break;
     default:
       reader.skipField();
@@ -468,9 +480,9 @@ proto.obb.PopularCombinationMarket.deserializeBinaryFromReader = function(msg, r
  * Serializes the message to binary data (in protobuf wire format).
  * @return {!Uint8Array}
  */
-proto.obb.PopularCombinationMarket.prototype.serializeBinary = function() {
+proto.obb.PopularCombination.prototype.serializeBinary = function() {
   var writer = new jspb.BinaryWriter();
-  proto.obb.PopularCombinationMarket.serializeBinaryToWriter(this, writer);
+  proto.obb.PopularCombination.serializeBinaryToWriter(this, writer);
   return writer.getResultBuffer();
 };
 
@@ -478,23 +490,30 @@ proto.obb.PopularCombinationMarket.prototype.serializeBinary = function() {
 /**
  * Serializes the given message to binary data (in protobuf wire
  * format), writing to the given BinaryWriter.
- * @param {!proto.obb.PopularCombinationMarket} message
+ * @param {!proto.obb.PopularCombination} message
  * @param {!jspb.BinaryWriter} writer
  * @suppress {unusedLocalVariables} f is only used for nested messages
  */
-proto.obb.PopularCombinationMarket.serializeBinaryToWriter = function(message, writer) {
+proto.obb.PopularCombination.serializeBinaryToWriter = function(message, writer) {
   var f = undefined;
-  f = message.getMarketId();
-  if (f !== 0) {
-    writer.writeUint32(
+  f = message.getSelectionIdsList();
+  if (f.length > 0) {
+    writer.writeRepeatedString(
       1,
       f
     );
   }
-  f = message.getSpecifiers();
-  if (f.length > 0) {
-    writer.writeString(
+  f = message.getOdds();
+  if (f !== 0) {
+    writer.writeUint64(
       2,
+      f
+    );
+  }
+  f = message.getRawProbability();
+  if (f !== 0.0) {
+    writer.writeDouble(
+      3,
       f
     );
   }
@@ -502,38 +521,75 @@ proto.obb.PopularCombinationMarket.serializeBinaryToWriter = function(message, w
 
 
 /**
- * optional uint32 market_id = 1;
- * @return {number}
+ * repeated string selection_ids = 1;
+ * @return {!Array<string>}
  */
-proto.obb.PopularCombinationMarket.prototype.getMarketId = function() {
-  return /** @type {number} */ (jspb.Message.getFieldWithDefault(this, 1, 0));
+proto.obb.PopularCombination.prototype.getSelectionIdsList = function() {
+  return /** @type {!Array<string>} */ (jspb.Message.getRepeatedField(this, 1));
 };
 
 
 /**
- * @param {number} value
- * @return {!proto.obb.PopularCombinationMarket} returns this
+ * @param {!Array<string>} value
+ * @return {!proto.obb.PopularCombination} returns this
  */
-proto.obb.PopularCombinationMarket.prototype.setMarketId = function(value) {
-  return jspb.Message.setProto3IntField(this, 1, value);
-};
-
-
-/**
- * optional string specifiers = 2;
- * @return {string}
- */
-proto.obb.PopularCombinationMarket.prototype.getSpecifiers = function() {
-  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 2, ""));
+proto.obb.PopularCombination.prototype.setSelectionIdsList = function(value) {
+  return jspb.Message.setField(this, 1, value || []);
 };
 
 
 /**
  * @param {string} value
- * @return {!proto.obb.PopularCombinationMarket} returns this
+ * @param {number=} opt_index
+ * @return {!proto.obb.PopularCombination} returns this
  */
-proto.obb.PopularCombinationMarket.prototype.setSpecifiers = function(value) {
-  return jspb.Message.setProto3StringField(this, 2, value);
+proto.obb.PopularCombination.prototype.addSelectionIds = function(value, opt_index) {
+  return jspb.Message.addToRepeatedField(this, 1, value, opt_index);
+};
+
+
+/**
+ * Clears the list making it empty but non-null.
+ * @return {!proto.obb.PopularCombination} returns this
+ */
+proto.obb.PopularCombination.prototype.clearSelectionIdsList = function() {
+  return this.setSelectionIdsList([]);
+};
+
+
+/**
+ * optional uint64 odds = 2;
+ * @return {number}
+ */
+proto.obb.PopularCombination.prototype.getOdds = function() {
+  return /** @type {number} */ (jspb.Message.getFieldWithDefault(this, 2, 0));
+};
+
+
+/**
+ * @param {number} value
+ * @return {!proto.obb.PopularCombination} returns this
+ */
+proto.obb.PopularCombination.prototype.setOdds = function(value) {
+  return jspb.Message.setProto3IntField(this, 2, value);
+};
+
+
+/**
+ * optional double raw_probability = 3;
+ * @return {number}
+ */
+proto.obb.PopularCombination.prototype.getRawProbability = function() {
+  return /** @type {number} */ (jspb.Message.getFloatingPointFieldWithDefault(this, 3, 0.0));
+};
+
+
+/**
+ * @param {number} value
+ * @return {!proto.obb.PopularCombination} returns this
+ */
+proto.obb.PopularCombination.prototype.setRawProbability = function(value) {
+  return jspb.Message.setProto3FloatField(this, 3, value);
 };
 
 

--- a/proto/obb/popular.proto
+++ b/proto/obb/popular.proto
@@ -11,15 +11,28 @@ message PopularCombinationRequest {
 }
 
 message PopularCombinationResponse {
-  // List of popular markets for OBB combinations.
-  repeated PopularCombinationMarket markets = 1;
+  // Field 1 was `repeated PopularCombinationMarket markets`; the endpoint
+  // never shipped, so the message was replaced without a migration path.
+  reserved 1;
+  reserved "markets";
+
+  // Popular selection combinations for the event, ready to be used
+  // in SessionCreateRequest without further processing.
+  repeated PopularCombination combinations = 2;
 }
 
-message PopularCombinationMarket {
-  // The ID using the same values as our odds feed in XML.
-  uint32 market_id = 1;
+message PopularCombination {
+  // Selections forming the combination, in the same format as
+  // SessionCreateRequest.selection_ids:
+  // "<event_id>/<market_id>/<outcome_id>?<market_specifier>"
+  // Example: "od:match:1234/1/1?map=1&way=two"
+  repeated string selection_ids = 1;
 
-  // The specifier is using the same values as our odds feed in XML.
-  // Example: "variant=way:three|way=three|map=1"
-  string specifiers = 2;
+  // Total odds for the whole combination.
+  // Odds multiplied by 10000 and rounded to uint value.
+  uint64 odds = 2;
+
+  // Raw probability of the combination (value between 0.0 and 1.0).
+  // This is the combined probability of all selections before margin is applied.
+  double raw_probability = 3;
 }

--- a/python/obb/popular_pb2.py
+++ b/python/obb/popular_pb2.py
@@ -24,7 +24,7 @@ _sym_db = _symbol_database.Default()
 
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x11obb/popular.proto\x12\x03obb\"6\n\x19PopularCombinationRequest\x12\x19\n\x08\x65vent_id\x18\x01 \x01(\tR\x07\x65ventId\"U\n\x1aPopularCombinationResponse\x12\x37\n\x07markets\x18\x01 \x03(\x0b\x32\x1d.obb.PopularCombinationMarketR\x07markets\"W\n\x18PopularCombinationMarket\x12\x1b\n\tmarket_id\x18\x01 \x01(\rR\x08marketId\x12\x1e\n\nspecifiers\x18\x02 \x01(\tR\nspecifiersB5\n\rcom.oddin.obbZ$github.com/oddin-gg/obbschema/go/obbb\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x11obb/popular.proto\x12\x03obb\"6\n\x19PopularCombinationRequest\x12\x19\n\x08\x65vent_id\x18\x01 \x01(\tR\x07\x65ventId\"h\n\x1aPopularCombinationResponse\x12;\n\x0c\x63ombinations\x18\x02 \x03(\x0b\x32\x17.obb.PopularCombinationR\x0c\x63ombinationsJ\x04\x08\x01\x10\x02R\x07markets\"v\n\x12PopularCombination\x12#\n\rselection_ids\x18\x01 \x03(\tR\x0cselectionIds\x12\x12\n\x04odds\x18\x02 \x01(\x04R\x04odds\x12\'\n\x0fraw_probability\x18\x03 \x01(\x01R\x0erawProbabilityB5\n\rcom.oddin.obbZ$github.com/oddin-gg/obbschema/go/obbb\x06proto3')
 
 _globals = globals()
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
@@ -35,7 +35,7 @@ if not _descriptor._USE_C_DESCRIPTORS:
   _globals['_POPULARCOMBINATIONREQUEST']._serialized_start=26
   _globals['_POPULARCOMBINATIONREQUEST']._serialized_end=80
   _globals['_POPULARCOMBINATIONRESPONSE']._serialized_start=82
-  _globals['_POPULARCOMBINATIONRESPONSE']._serialized_end=167
-  _globals['_POPULARCOMBINATIONMARKET']._serialized_start=169
-  _globals['_POPULARCOMBINATIONMARKET']._serialized_end=256
+  _globals['_POPULARCOMBINATIONRESPONSE']._serialized_end=186
+  _globals['_POPULARCOMBINATION']._serialized_start=188
+  _globals['_POPULARCOMBINATION']._serialized_end=306
 # @@protoc_insertion_point(module_scope)


### PR DESCRIPTION
[Link to JIRA ticket](https://oddingg.atlassian.net/browse/CORE-3868)

## Why

The PopularCombination endpoint never shipped (fujin has always returned `Unimplemented`), and its response shape — a list of markets — would force clients to re-assemble selections themselves. The quick-picks product needs the offer to be one-click creatable: the client must be able to echo the offer straight into `SessionCreateRequest` without any assembly of its own.

## What

`PopularCombinationResponse` is replaced without a migration path (no producer ever emitted the old shape):

- `combinations` — each entry carries `selection_ids` in the exact `SessionCreateRequest.selection_ids` format, total `odds` (×10 000, same convention as the session protos) and `raw_probability` (pre-margin, 0.0–1.0).
- The old `repeated PopularCombinationMarket markets = 1` field is deleted; field number **and** name are `reserved` — kollector v0.7.0 has compiled (dead) references to the old shape, and reserving keeps a stale decoder failing soft instead of hitting a wire-type mismatch if the number were reused.
- Generated bindings regenerated for all languages (go/java/js/python).

## After merge

Tag **v0.9.0** — fujin's PopularCombination implementation (CORE-3868) depends on it, and kollector's next obbschema bump must drop its dead `PopularCombinationMarket` scaffolding.